### PR TITLE
When removing existing input entries, call jQuery find() prior to remove()

### DIFF
--- a/src/app/state.js
+++ b/src/app/state.js
@@ -19,7 +19,7 @@ function loadTags(element, data) {
   var terms = data.split(',');
   tags.forEach(function(tag) {
     if (terms.indexOf(tag) >= 0) return;
-    $(element).remove(`option[value='${tag}']`);
+    $(element).find(`option[value='${tag}']`).remove();
   });
   terms.forEach(function(term) {
     if (tags.indexOf(term) >= 0) return;


### PR DESCRIPTION
This was a slight misunderstanding about the behavior of the jQuery `remove` method - there's some more detail in https://bugs.jquery.com/ticket/7816

Calling `remove` from the parent selector performs a filter on the elements which are contained within that selector (i.e. which is a set containing a single element -the `select2` input box - in this case), and then removes those items from the DOM.

Calling `find` from the parent selector instead allows us to navigate through child DOM elements to the `option` elements we want to de-select, and then calling `remove` from that selector set removes them.