### PR TITLE
Re-render advanced search elements when visible

### DIFF
--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -134,11 +134,13 @@ $(function() {
   var state = getState();
   if (state.exclude || state.equipment) {
     $('#advanced-search').show();
+    $('#advanced-search select').trigger('change');
   }
   $('#advanced-toggle a').on('click', function() {
     if ($('#advanced-search').is(':hidden')) {
       $('#advanced-toggle .indicator').html('&#9650;');
       $('#advanced-search').slideDown();
+      $('#advanced-search select').trigger('change');
     } else {
       $('#advanced-toggle .indicator').html('&#9660;');
       $('#advanced-search').slideUp();

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -134,12 +134,14 @@ $(function() {
   var state = getState();
   if (state.exclude || state.equipment) {
     $('#advanced-search').show();
+    // TODO: Remove once https://github.com/select2/select2/issues/5585 fixed
     $('#advanced-search select').trigger('change');
   }
   $('#advanced-toggle a').on('click', function() {
     if ($('#advanced-search').is(':hidden')) {
       $('#advanced-toggle .indicator').html('&#9650;');
       $('#advanced-search').slideDown();
+      // TODO: Remove once https://github.com/select2/select2/issues/5585 fixed
       $('#advanced-search select').trigger('change');
     } else {
       $('#advanced-toggle .indicator').html('&#9660;');


### PR DESCRIPTION
When rendering multi-select boxes, `select2` dynamically sizes the placeholder element to match the size of the containing `select` element, by calling jQuery's `innerWidth` function.

Unfortunately there's a bug / behaviour in jQuery which returns a width (and height?) of zero for that element when it's not displayed.  That means that only placeholders inside elements which are visible on page load (i.e. the `#include` ingredient element) are shown.

This workaround triggers the `change` event on the additional 'advanced' search elements when the advanced search panel is shown.

Fixes #6 