### PR TITLE
Use stackonly, jquery variant of tablesaw

### DIFF
--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -1,6 +1,6 @@
 import 'jquery';
 import * as moment from 'moment';
-import 'tablesaw';
+import 'tablesaw/dist/stackonly/tablesaw.stackonly.jquery.js';
 
 import 'tablesaw/dist/stackonly/tablesaw.stackonly.css';
 import './recipe-list.css'


### PR DESCRIPTION
During the migration to an NPM-packaged version of `tablesaw`, there was a regression to use the default version of the library in the frontend application.

Since we already have jQuery available, and since we only need the table-resizing functionality from the `tablesaw` library, switch to using the `tablesaw.stackonly.jquery` variant.