### PR TITLE
Migrate from GA to Countly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@fortawesome/fontawesome-free": "^5.11.2",
     "bootstrap": "^4.3.1",
     "bootstrap-table": "^1.15.5",
+    "countly-sdk-web": "^19.8.0",
     "delta-crdts": "https://github.com/ipfs-shipyard/js-delta-crdts#639bce5c6d5afda423c0b6f4cef1c1901ca8c074",
     "jquery": "^3.4.1",
     "moment": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "css-loader": "^3.2.0",
     "eslint": "^6.6.0",
     "file-loader": "^5.0.2",
+    "git-revision-webpack-plugin": "^3.0.4",
     "html-webpack-plugin": "^3.2.0",
     "jsdom": "^15.2.1",
     "mini-css-extract-plugin": "^0.8.0",

--- a/src/app/models/recipes.js
+++ b/src/app/models/recipes.js
@@ -17,7 +17,6 @@ function addRecipe() {
     addProduct(product, recipe.id);
   });
 
-  gtag('event', 'add_to_cart');
   RecipeRadar.countly.add_event('addRecipe');
 }
 

--- a/src/app/models/recipes.js
+++ b/src/app/models/recipes.js
@@ -18,6 +18,7 @@ function addRecipe() {
   });
 
   gtag('event', 'add_to_cart');
+  RecipeRadar.countly.add_event('addRecipe');
 }
 
 function removeRecipe() {

--- a/src/app/models/starred.js
+++ b/src/app/models/starred.js
@@ -13,6 +13,7 @@ function starRecipe() {
   updateStarState(recipe.id);
 
   gtag('event', 'select_content');
+  RecipeRadar.countly.add_event('starRecipe');
 }
 
 function unstarRecipe() {

--- a/src/app/models/starred.js
+++ b/src/app/models/starred.js
@@ -12,7 +12,6 @@ function starRecipe() {
   storage.starred.add({'hashCode': recipe.id, 'value': recipe});
   updateStarState(recipe.id);
 
-  gtag('event', 'select_content');
   RecipeRadar.countly.add_event('starRecipe');
 }
 

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -192,6 +192,7 @@ function selectTab() {
 
 function recipeRedirect() {
   gtag('event', 'generate_lead');
+  RecipeRadar.countly.add_event('recipeRedirect');
 }
 
 function bindPostBody(selector) {

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -191,7 +191,6 @@ function selectTab() {
 }
 
 function recipeRedirect() {
-  gtag('event', 'generate_lead');
   RecipeRadar.countly.add_event('recipeRedirect');
 }
 

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -115,6 +115,7 @@ function scheduleMeal(evt) {
 
   if (toRow.length && !fromRow.length) {
     gtag('event', 'add_to_wishlist');
+    RecipeRadar.countly.add_event('scheduleMeal');
   }
 }
 

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -114,7 +114,6 @@ function scheduleMeal(evt) {
   }
 
   if (toRow.length && !fromRow.length) {
-    gtag('event', 'add_to_wishlist');
     RecipeRadar.countly.add_event('scheduleMeal');
   }
 }

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -44,6 +44,7 @@ function renderSearch() {
   loadPage('search');
   scrollToResults('#search');
   gtag('event', 'search');
+  RecipeRadar.countly.add_event('renderSearch');
 }
 
 function renderIndividual() {

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -43,7 +43,6 @@ function renderSearch() {
 
   loadPage('search');
   scrollToResults('#search');
-  gtag('event', 'search');
   RecipeRadar.countly.add_event('renderSearch');
 }
 

--- a/src/countly/index.js
+++ b/src/countly/index.js
@@ -8,6 +8,7 @@ var countlyURI = hostURI.replace(hostname, countlyHostname);
 
 Countly.init({
   app_key: 'tbd',
+  app_version: `${VERSION}`,
   force_post: true,
   url: countlyURI,
   use_session_cookie: false

--- a/src/countly/index.js
+++ b/src/countly/index.js
@@ -16,3 +16,6 @@ Countly.init({
 Countly.track_sessions()
 Countly.track_pageview()
 Countly.track_errors()
+
+const add_event = Countly.add_event;
+export { add_event };

--- a/src/countly/index.js
+++ b/src/countly/index.js
@@ -1,0 +1,1 @@
+import { Countly } from 'countly-sdk-web';

--- a/src/countly/index.js
+++ b/src/countly/index.js
@@ -7,7 +7,7 @@ var countlyHostname = `countly.${hostname}`;
 var countlyURI = hostURI.replace(hostname, countlyHostname);
 
 Countly.init({
-  app_key: 'tbd',
+  app_key: 'cbe9c80e3bae3df51d71ae0fbbfa6498d22c42ca',
   app_version: `${VERSION}`,
   force_post: true,
   url: countlyURI,

--- a/src/countly/index.js
+++ b/src/countly/index.js
@@ -1,1 +1,17 @@
-import { Countly } from 'countly-sdk-web';
+import Countly from 'countly-sdk-web';
+
+var hostname = window.location.hostname;
+var hostURI = window.location.href.split('#')[0];
+
+var countlyHostname = `countly.${hostname}`;
+var countlyURI = hostURI.replace(hostname, countlyHostname);
+
+Countly.init({
+  app_key: 'tbd',
+  force_post: true,
+  url: countlyURI,
+  use_session_cookie: false
+});
+Countly.track_sessions()
+Countly.track_pageview()
+Countly.track_errors()

--- a/src/index.html
+++ b/src/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <link rel="preconnect" href="https://www.google-analytics.com">
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-146803556-1"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-146803556-1');
-    </script>
     <meta charset="utf-8" />
     <meta name="description" content="Find recipes and plan your weekly meals with RecipeRadar" />
     <meta name="theme-color" content="#07f" />

--- a/src/index.html
+++ b/src/index.html
@@ -149,6 +149,6 @@
       </div>
     </footer>
 
-    <%= htmlWebpackPlugin.files.js.map(src => `<script type="text/javascript" src="${src}"></script>`).join('\n    ') %>
+    <%= htmlWebpackPlugin.files.js.map(src => `<script type="text/javascript" src="${src}"${src.match(/^app\./) ? '' : ' async'}></script>`).join('\n    ') %>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
     mode: 'development',
     entry: {
       'app': path.resolve(__dirname, 'src/app/main.js'),
+      'countly': path.resolve(__dirname, 'src/countly/index.js'),
       'feedback': path.resolve(__dirname, 'src/feedback/loader.js'),
       'sw': path.resolve(__dirname, 'src/sw/loader.js')
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const { InjectManifest } = require('workbox-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const GitRevisionPlugin = require('git-revision-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
@@ -28,6 +29,9 @@ module.exports = {
       ]),
       new MiniCssExtractPlugin({
         filename: '[name].[chunkhash].css'
+      }),
+      new webpack.DefinePlugin({
+        'VERSION': JSON.stringify(new GitRevisionPlugin().version())
       }),
       new webpack.ProvidePlugin({
         '$': 'jquery',


### PR DESCRIPTION
Once https://github.com/openculinary/infrastructure/pull/4 is deployed, the frontend application can be migrated to use Countly.

Todo:

- [x] Generate a production application key