### PR TITLE
Use NetworkFirst strategy for root path

### DIFF
--- a/src/sw/sw.js
+++ b/src/sw/sw.js
@@ -23,5 +23,9 @@ workbox.routing.registerRoute(
   searchHandler
 );
 
-workbox.precaching.precacheAndRoute(['/']);
+workbox.routing.registerRoute(
+  '/',
+  new workbox.strategies.NetworkFirst()
+);
+
 workbox.precaching.precacheAndRoute(self.__precacheManifest);


### PR DESCRIPTION
Using `precacheAndRoute` on the root URL seems to cache too aggressively; it results in situations where a stale version of the root path (aka `index.html`) is served to the user, which may lead to failures to download the corresponding CSS & JS.

`StaleWhileRevalidate` *might* be a suitable choice for strategy here too, but `NetworkFirst` seems more guaranteed to gather us the latest application content, ensure that assets are up-to-date while online, and still support offline operation/application loading.