### PR TITLE
Workaround: jquery-apply aria-label to searchboxes

### DIFF
--- a/src/app/autosuggest.js
+++ b/src/app/autosuggest.js
@@ -3,7 +3,7 @@ import 'select2';
 
 import 'select2/dist/css/select2.css';
 
-function bindEquipmentInput(element, placeholder) {
+function bindEquipmentInput(element, label, placeholder) {
   $(element).select2({
     ajax: {
       url: 'api/equipment',
@@ -20,9 +20,12 @@ function bindEquipmentInput(element, placeholder) {
     placeholder: placeholder,
     selectOnClose: true
   });
+
+  // TODO: Revisit once https://github.com/select2/select2/issues/3744 is handled
+  $(element).siblings('.select2').find('input[type=search]').attr('aria-label', label);
 }
 
-function bindIngredientInput(element, placeholder) {
+function bindIngredientInput(element, label, placeholder) {
   $(element).select2({
     ajax: {
       url: 'api/ingredients',
@@ -39,12 +42,15 @@ function bindIngredientInput(element, placeholder) {
     placeholder: placeholder,
     selectOnClose: true
   });
+
+  // TODO: Revisit once https://github.com/select2/select2/issues/3744 is handled
+  $(element).siblings('.select2').find('input[type=search]').attr('aria-label', label);
 }
 
 $(function() {
-  bindIngredientInput('#include', 'e.g. tomatoes');
-  bindIngredientInput('#exclude', 'e.g. mushrooms');
-  bindEquipmentInput('#equipment', 'e.g. slow cooker');
+  bindIngredientInput('#include', 'Ingredients to include', 'e.g. tomatoes');
+  bindIngredientInput('#exclude', 'Ingredients to exclude', 'e.g. mushrooms');
+  bindEquipmentInput('#equipment', 'Kitchen equipment to use', 'e.g. slow cooker');
 
   $(document).on('keyup', '.select2-search__field', function (event) {
     if (event.keyCode == 13) {


### PR DESCRIPTION
It'd be nice if these labels could be applied via markup or as parameters to `select2`, but in the meantime we can use `jquery` to set `aria-label` attributes after the controls are created.

The situation may be improved once https://github.com/select2/select2/issues/3744 is handled, so it's worth revisiting at that point.