### PR TITLE
Unit conversion and dynamic rendering of ingredient quantities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Source code for the application is divided into three Javascript components:
 * `src/feedback` - in-application feedback form based on [feedback.js](https://experiments.hertzen.com/jsfeedback)
 * `src/sw` - application [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API)
 
+The following resources are useful guides for designing ingredient and recipe rendering:
+
+* [The Metric Kitchen - Style Guide](https://www.jsward.com/cooking/style.shtml)
+* [Wikipedia - Cooking weights and measures](https://en.wikipedia.org/wiki/Cooking_weights_and_measures)
+
 ## Install dependencies
 
 Make sure to follow the RecipeRadar [infrastructure](https://www.github.com/openculinary/infrastructure) setup to ensure all cluster dependencies are available in your environment.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "bootstrap": "^4.3.1",
     "bootstrap-table": "^1.15.5",
     "countly-sdk-web": "^19.8.0",
+    "convert-units": "^2.3.4",
     "delta-crdts": "https://github.com/ipfs-shipyard/js-delta-crdts#639bce5c6d5afda423c0b6f4cef1c1901ca8c074",
     "jquery": "^3.4.1",
     "moment": "^2.24.0",

--- a/src/app/common.js
+++ b/src/app/common.js
@@ -64,7 +64,7 @@ function getRecipe(el) {
 }
 
 function float2rat(x) {
-    var tolerance = 1.0E-2;
+    var tolerance = 0.1;
     var h1=1; var h2=0;
     var k1=0; var k2=1;
     var b = x;

--- a/src/app/common.js
+++ b/src/app/common.js
@@ -75,10 +75,10 @@ function float2rat(x) {
         b = 1/(b-a);
     } while (Math.abs(x-h1/k1) > x*tolerance);
 
-    if (k1 === 1) return h1;
+    if (k1 === 1) return `${h1}`;
     if (h1 > k1) {
         h1 = Math.floor(h1 / k1);
-        return h1+" 1/"+k1;
+        return `${h1} 1/${k1}`;
     }
-    return h1+"/"+k1;
+    return `${h1}/${k1}`;
 }

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -4,6 +4,11 @@ import { float2rat } from './common';
 
 export { renderQuantity };
 
+const expandMeasures = [
+    'Tbs',
+    'tsp',
+];
+
 function volumeUnits(quantity) {
   if (quantity.val >= 1000) return 'l';
   if (quantity.val <= 5) return 'tsp';
@@ -24,29 +29,31 @@ function targetUnits(quantity) {
   };
 }
 
-function renderMagnitude(magnitude) {
-  var result = float2rat(magnitude);
-  if (result.indexOf('/') >= 0) {
-    result = result.replace('/', '</sup>&frasl;<sub>');
-    return `<sup>${result}</sub>`;
+function renderMagnitude(units, magnitude) {
+  if (expandMeasures.indexOf(units) == -1) {
+    return magnitude.toFixed(2) / 1;
   }
-  return result;
+  var result = float2rat(magnitude);
+  if (result.indexOf('/') == -1) {
+    return result;
+  }
+  result = result.replace('/', '</sup>&frasl;<sub>');
+  return `<sup>${result}</sub>`;
 }
 
 function renderUnits(units, magnitude) {
   var description = convert().describe(units);
-  var expandMeasures = ['Tbs', 'tsp'];
-  if (expandMeasures.indexOf(units) >= 0) {
-    if (magnitude === 1) return description.singular.toLowerCase();
-    return description.plural.toLowerCase();
+  if (expandMeasures.indexOf(units) == -1) {
+    return description.abbr;
   }
-  return description.abbr;
+  if (magnitude === 1) return description.singular.toLowerCase();
+  return description.plural.toLowerCase();
 }
 
 function renderQuantity(quantity) {
   var units = targetUnits(quantity);
   var magnitude = quantity.to(units);
-  var renderedMagnitude = renderMagnitude(magnitude);
+  var renderedMagnitude = renderMagnitude(units, magnitude);
   var renderedUnits = renderUnits(units, magnitude);
   return `${renderedMagnitude} ${renderedUnits}`;
 }

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -87,5 +87,5 @@ function renderQuantity(quantity) {
 function renderIngredient(ingredient) {
   var renderedQuantity = renderQuantity(ingredient.quantity);
   var renderedProduct = renderProduct(ingredient.product);
-  return `<td>${renderedQuantity}</td><td>${renderedProduct}</td>`;
+  return `<th>${renderedQuantity}</th><td>${renderedProduct}</td>`;
 }

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -31,6 +31,7 @@ function targetUnits(quantity) {
   switch (measure) {
     case 'volume': return volumeUnits(quantity);
     case 'mass': return weightUnits(quantity);
+    default: return quantity.origin.abbr;
   };
 }
 

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -25,7 +25,7 @@ function weightUnits(quantity) {
 function targetUnits(quantity) {
   switch (quantity.origin.measure) {
     case 'volume': return volumeUnits(quantity);
-    case 'weight': return weightUnits(quantity);
+    case 'mass': return weightUnits(quantity);
   };
 }
 

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -2,7 +2,7 @@ import * as convert from 'convert-units';
 
 import { float2rat } from './common';
 
-export { renderQuantity };
+export { renderIngredient };
 
 const expandMeasures = [
     'Tbs',
@@ -50,8 +50,8 @@ function renderUnits(units, magnitude) {
   return description.plural.toLowerCase();
 }
 
-function renderQuantity(quantity) {
-  quantity = convert(quantity.magnitude).from(quantity.units);
+function renderIngredient(ingredient) {
+  var quantity = convert(ingredient.quantity).from(ingredient.units);
   var units = targetUnits(quantity);
   var magnitude = quantity.to(units);
   var renderedMagnitude = renderMagnitude(units, magnitude);

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -30,6 +30,12 @@ function targetUnits(quantity) {
 }
 
 function renderMagnitude(units, magnitude) {
+  if (magnitude >= 50) {
+    magnitude = magnitude / 5;
+    magnitude = Math.round(magnitude) * 5;
+    magnitude = Number(magnitude.toPrecision(3));
+    return magnitude.toFixed();
+  }
   if (expandMeasures.indexOf(units) == -1) {
     return magnitude.toFixed(2) / 1;
   }

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -51,6 +51,7 @@ function renderUnits(units, magnitude) {
 }
 
 function renderQuantity(quantity) {
+  quantity = convert(quantity.magnitude).from(quantity.units);
   var units = targetUnits(quantity);
   var magnitude = quantity.to(units);
   var renderedMagnitude = renderMagnitude(units, magnitude);

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -18,8 +18,6 @@ function volumeUnits(quantity) {
 
 function weightUnits(quantity) {
   if (quantity.val >= 1000) return 'kg';
-  // TODO: Support custom rendering units
-  // if (quantity.val <= 1) return 'pinch';
   return 'g';
 }
 
@@ -71,6 +69,15 @@ function renderUnits(units, magnitude) {
 }
 
 function renderQuantity(quantity) {
+
+  // Special case handling for 'pinch'
+  if (quantity.units === 'ml' && quantity.magnitude <= 0.25) {
+    return {
+      'magnitude': null,
+      'units': 'pinch'
+    };
+  }
+
   var fromQuantity;
   try {
     fromQuantity = convert(quantity.magnitude).from(quantity.units);

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -18,7 +18,8 @@ function volumeUnits(quantity) {
 
 function weightUnits(quantity) {
   if (quantity.val >= 1000) return 'kg';
-  if (quantity.val <= 1) return 'pinch';
+  // TODO: Support custom rendering units
+  // if (quantity.val <= 1) return 'pinch';
   return 'g';
 }
 

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -11,8 +11,8 @@ const expandMeasures = [
 
 function volumeUnits(quantity) {
   if (quantity.val >= 1000) return 'l';
-  if (quantity.val <= 5) return 'tsp';
-  if (quantity.val <= 20) return 'Tbs';
+  if (quantity.val <= 15) return 'tsp';
+  if (quantity.val <= 45) return 'Tbs';
   return 'ml';
 }
 
@@ -23,7 +23,11 @@ function weightUnits(quantity) {
 }
 
 function targetUnits(quantity) {
-  switch (quantity.origin.measure) {
+  var measure = quantity.origin.measure;
+  if (expandMeasures.indexOf(measure) >= 0) {
+    return measure;
+  }
+  switch (measure) {
     case 'volume': return volumeUnits(quantity);
     case 'mass': return weightUnits(quantity);
   };

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -1,0 +1,33 @@
+import * as convert from 'convert-units';
+
+import { float2rat } from './common';
+
+export { renderQuantity };
+
+function volumeUnits(quantity) {
+  if (quantity.val >= 1000) return 'l';
+  if (quantity.val <= 5) return 'tsp';
+  if (quantity.val <= 20) return 'Tbs';
+  return 'ml';
+}
+
+function weightUnits(quantity) {
+  if (quantity.val >= 1000) return 'kg';
+  if (quantity.val <= 1) return 'pinch';
+  return 'g';
+}
+
+function targetUnits(quantity) {
+  switch (quantity.origin.measure) {
+    case 'volume': return volumeUnits(quantity);
+    case 'weight': return weightUnits(quantity);
+  };
+}
+
+function renderQuantity(quantity) {
+  var units = targetUnits(quantity);
+  var unitDescription = convert().describe(units);
+  var magnitude = float2rat(quantity.to(units));
+
+  return `${magnitude} ${unitDescription.abbr}`;
+}

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -55,9 +55,16 @@ function renderUnits(units, magnitude) {
 }
 
 function renderQuantity(quantity) {
-  var quantity = convert(quantity.magnitude).from(quantity.units);
-  var units = targetUnits(quantity);
-  var magnitude = quantity.to(units);
+  var fromQuantity;
+  try {
+    fromQuantity = convert(quantity.magnitude).from(quantity.units);
+  } catch (e) {
+    return `${quantity.magnitude} ${quantity.units}`;
+  }
+
+  var units = targetUnits(fromQuantity);
+  var magnitude = fromQuantity.to(units);
+
   var renderedMagnitude = renderMagnitude(units, magnitude);
   var renderedUnits = renderUnits(units, magnitude);
   return `${renderedMagnitude} ${renderedUnits}`;

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -75,7 +75,10 @@ function renderQuantity(quantity) {
   try {
     fromQuantity = convert(quantity.magnitude).from(quantity.units);
   } catch (e) {
-    return `${quantity.magnitude} ${quantity.units}`;
+    return {
+      'magnitude': quantity.magnitude,
+      'units': quantity.units
+    };
   }
 
   var units = targetUnits(fromQuantity);
@@ -83,11 +86,17 @@ function renderQuantity(quantity) {
 
   var renderedMagnitude = renderMagnitude(units, magnitude);
   var renderedUnits = renderUnits(units, magnitude);
-  return `${renderedMagnitude} ${renderedUnits}`;
+  return {
+    'magnitude': renderedMagnitude,
+    'units': renderedUnits
+  };
 }
 
 function renderIngredient(ingredient) {
   var renderedQuantity = renderQuantity(ingredient.quantity);
   var renderedProduct = renderProduct(ingredient.product);
-  return `<th>${renderedQuantity}</th><td>${renderedProduct}</td>`;
+  return {
+    'quantity': renderedQuantity,
+    'product': renderedProduct
+  }
 }

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -87,5 +87,5 @@ function renderQuantity(quantity) {
 function renderIngredient(ingredient) {
   var renderedQuantity = renderQuantity(ingredient.quantity);
   var renderedProduct = renderProduct(ingredient.product);
-  return `${renderedQuantity} ${renderedProduct}`;
+  return `<td>${renderedQuantity}</td><td>${renderedProduct}</td>`;
 }

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -2,7 +2,7 @@ import * as convert from 'convert-units';
 
 import { float2rat } from './common';
 
-export { renderIngredient };
+export { renderQuantity, renderIngredient };
 
 const expandMeasures = [
     'Tbs',
@@ -41,6 +41,10 @@ function renderMagnitude(units, magnitude) {
   return `<sup>${result}</sub>`;
 }
 
+function renderProduct(product) {
+  return `<span class="tag badge ${product.state}">${product.product}</span>`;
+}
+
 function renderUnits(units, magnitude) {
   var description = convert().describe(units);
   if (expandMeasures.indexOf(units) == -1) {
@@ -50,11 +54,17 @@ function renderUnits(units, magnitude) {
   return description.plural.toLowerCase();
 }
 
-function renderIngredient(ingredient) {
-  var quantity = convert(ingredient.quantity).from(ingredient.units);
+function renderQuantity(quantity) {
+  var quantity = convert(quantity.magnitude).from(quantity.units);
   var units = targetUnits(quantity);
   var magnitude = quantity.to(units);
   var renderedMagnitude = renderMagnitude(units, magnitude);
   var renderedUnits = renderUnits(units, magnitude);
   return `${renderedMagnitude} ${renderedUnits}`;
+}
+
+function renderIngredient(ingredient) {
+  var renderedQuantity = renderQuantity(ingredient.quantity);
+  var renderedProduct = renderProduct(ingredient.product);
+  return `${renderedQuantity} ${renderedProduct}`;
 }

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -24,7 +24,16 @@ function targetUnits(quantity) {
   };
 }
 
-function describeUnits(units, magnitude) {
+function renderMagnitude(magnitude) {
+  var result = float2rat(magnitude);
+  if (result.indexOf('/') >= 0) {
+    result = result.replace('/', '</sup>&frasl;<sub>');
+    return `<sup>${result}</sub>`;
+  }
+  return result;
+}
+
+function renderUnits(units, magnitude) {
   var description = convert().describe(units);
   var expandMeasures = ['Tbs', 'tsp'];
   if (expandMeasures.indexOf(units) >= 0) {
@@ -36,8 +45,8 @@ function describeUnits(units, magnitude) {
 
 function renderQuantity(quantity) {
   var units = targetUnits(quantity);
-  var magnitude = float2rat(quantity.to(units));
-  var unitDescription = describeUnits(units, magnitude);
-
-  return `${magnitude} ${unitDescription}`;
+  var magnitude = quantity.to(units);
+  var renderedMagnitude = renderMagnitude(magnitude);
+  var renderedUnits = renderUnits(units, magnitude);
+  return `${renderedMagnitude} ${renderedUnits}`;
 }

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -24,10 +24,20 @@ function targetUnits(quantity) {
   };
 }
 
+function describeUnits(units, magnitude) {
+  var description = convert().describe(units);
+  var expandMeasures = ['Tbs', 'tsp'];
+  if (expandMeasures.indexOf(units) >= 0) {
+    if (magnitude === 1) return description.singular.toLowerCase();
+    return description.plural.toLowerCase();
+  }
+  return description.abbr;
+}
+
 function renderQuantity(quantity) {
   var units = targetUnits(quantity);
-  var unitDescription = convert().describe(units);
   var magnitude = float2rat(quantity.to(units));
+  var unitDescription = describeUnits(units, magnitude);
 
-  return `${magnitude} ${unitDescription.abbr}`;
+  return `${magnitude} ${unitDescription}`;
 }

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -43,8 +43,12 @@ function renderMagnitude(units, magnitude) {
   if (result.indexOf('/') == -1) {
     return result;
   }
-  result = result.replace('/', '</sup>&frasl;<sub>');
-  return `<sup>${result}</sub>`;
+  result = result.split(' ');
+  var last = result.length - 1;
+  result[last] = result[last].replace('/', '</sup>&frasl;<sub>');
+  result[last] = `<sup>${result[last]}</sub>`;
+  result = result.join(' ');
+  return result;
 }
 
 function renderProduct(product) {
@@ -56,7 +60,7 @@ function renderUnits(units, magnitude) {
   if (expandMeasures.indexOf(units) == -1) {
     return description.abbr;
   }
-  if (magnitude === 1) return description.singular.toLowerCase();
+  if (magnitude <= 1) return description.singular.toLowerCase();
   return description.plural.toLowerCase();
 }
 

--- a/src/app/ui/recipe-list.css
+++ b/src/app/ui/recipe-list.css
@@ -117,7 +117,7 @@ div.recipe-list .content .tab button {
 div.recipe-list .content .ingredients table th {
   padding: 1px;
 
-  width: 200px;
+  width: 120px;
   text-align: right;
   font-weight: normal;
 }

--- a/src/app/ui/recipe-list.css
+++ b/src/app/ui/recipe-list.css
@@ -113,3 +113,9 @@ div.recipe-list .content .tab {
 div.recipe-list .content .tab button {
   margin-top: 1rem;
 }
+
+div.recipe-list .content .ingredients table th {
+  width: 200px;
+  text-align: right;
+  font-weight: normal;
+}

--- a/src/app/ui/recipe-list.css
+++ b/src/app/ui/recipe-list.css
@@ -114,14 +114,17 @@ div.recipe-list .content .tab button {
   margin-top: 1rem;
 }
 
-div.recipe-list .content .ingredients table th {
-  padding: 1px;
-
+div.recipe-list .content .ingredients .quantity {
+  clear: both;
+  float: left;
   width: 120px;
   text-align: right;
-  font-weight: normal;
+
+  padding: 2px;
 }
 
-div.recipe-list .content .ingredients table td {
-  padding: 1px;
+div.recipe-list .content .ingredients .product {
+  float: left;
+
+  padding: 2px;
 }

--- a/src/app/ui/recipe-list.css
+++ b/src/app/ui/recipe-list.css
@@ -115,7 +115,13 @@ div.recipe-list .content .tab button {
 }
 
 div.recipe-list .content .ingredients table th {
+  padding: 1px;
+
   width: 200px;
   text-align: right;
   font-weight: normal;
+}
+
+div.recipe-list .content .ingredients table td {
+  padding: 1px;
 }

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -44,12 +44,12 @@ function renderIngredients(tokens) {
         units: collectedTokens.units
       }
     });
-    return `<th>${ingredient.quantity.magnitude} ${ingredient.quantity.units}</th><td>${ingredient.product}</td>`
+    return `<div class="quantity">${ingredient.quantity.magnitude} ${ingredient.quantity.units}</div><div class="product">${ingredient.product}</div>`
   }
 
   var quantity = renderTokens(tokens.filter(token => token.type != 'product'));
   var product = renderTokens(tokens.filter(token => token.type == 'product'));
-  return `<th>${quantity}</th><td>${product}</td>`;
+  return `<div class="quantity">${quantity}</div><div class="product">${product}</div>`;
 }
 
 function renderToken(token) {
@@ -125,9 +125,10 @@ function contentFormatter(recipe) {
   content.append(tabs);
 
   var ingredients = $('<div />', {'class': 'tab ingredients'});
-  var ingredientList = $('<table />');
+  var ingredientList = $('<div  />');
   $.each(recipe.ingredients, function() {
-    ingredientList.append($('<tr />', {'html': renderIngredients(this.tokens)}));
+    ingredientList.append(renderIngredients(this.tokens));
+    ingredientList.append($('<div  />', {'style': 'clear: both'}));
   });
   ingredients.append(ingredientList);
   ingredients.append($('<button />', {

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -46,7 +46,7 @@ function renderIngredients(tokens) {
     });
   }
   var renderedIngredient = renderTokens(tokens);
-  return `<td></td><td>${renderedIngredient}</td>`;
+  return `<th></th><td>${renderedIngredient}</td>`;
 }
 
 function renderToken(token) {

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -7,6 +7,7 @@ import 'tablesaw/dist/stackonly/tablesaw.stackonly.css';
 import './recipe-list.css'
 
 import { float2rat, getRecipe } from '../common';
+import { renderIngredient } from '../conversion';
 import { getState } from '../state';
 import { storage } from '../storage';
 import { addRecipe } from '../models/recipes';
@@ -21,6 +22,27 @@ export {
     updateRecipeState,
     updateStarState,
 };
+
+function renderTokens(tokens) {
+  var collectedTokens = {};
+  tokens.map(token => {
+    collectedTokens[token.type] = token.value;
+    if (token.type === 'product') collectedTokens.product = {
+      product: token.value,
+      state: token.state,
+    };
+  });
+  if (collectedTokens.product && collectedTokens.quantity && collectedTokens.units) {
+    return renderIngredient({
+      product: collectedTokens.product,
+      quantity: {
+        magnitude: collectedTokens.quantity,
+        units: collectedTokens.units
+      }
+    });
+  }
+  return tokens.map(renderToken).join('');
+}
 
 function renderToken(token) {
   switch (token.type) {
@@ -97,7 +119,7 @@ function contentFormatter(recipe) {
   var ingredients = $('<div />', {'class': 'tab ingredients'});
   var ingredientList = $('<ul />');
   $.each(recipe.ingredients, function() {
-    ingredientList.append($('<li />', {'html': this.tokens.map(renderToken).join('')}));
+    ingredientList.append($('<li />', {'html': renderTokens(this.tokens)}));
   });
   ingredients.append(ingredientList);
   ingredients.append($('<button />', {
@@ -109,7 +131,7 @@ function contentFormatter(recipe) {
   var directions = $('<div />', {'class': 'tab directions collapse'});
   var directionList = $('<ul />');
   $.each(recipe.directions, function() {
-    directionList.append($('<li />', {'html': this.tokens.map(renderToken).join('')}));
+    directionList.append($('<li />', {'html': renderTokens(this.tokens)}));
   });
   directions.append(directionList);
   content.append(directions);

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -24,6 +24,10 @@ export {
 };
 
 function renderTokens(tokens) {
+  return tokens.map(renderToken).join('');
+}
+
+function renderIngredients(tokens) {
   var collectedTokens = {};
   tokens.map(token => {
     collectedTokens[token.type] = token.value;
@@ -41,7 +45,7 @@ function renderTokens(tokens) {
       }
     });
   }
-  return tokens.map(renderToken).join('');
+  return renderTokens(tokens);
 }
 
 function renderToken(token) {
@@ -119,7 +123,7 @@ function contentFormatter(recipe) {
   var ingredients = $('<div />', {'class': 'tab ingredients'});
   var ingredientList = $('<ul />');
   $.each(recipe.ingredients, function() {
-    ingredientList.append($('<li />', {'html': renderTokens(this.tokens)}));
+    ingredientList.append($('<li />', {'html': renderIngredients(this.tokens)}));
   });
   ingredients.append(ingredientList);
   ingredients.append($('<button />', {

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -45,8 +45,10 @@ function renderIngredients(tokens) {
       }
     });
   }
-  var renderedIngredient = renderTokens(tokens);
-  return `<th></th><td>${renderedIngredient}</td>`;
+
+  var quantity = renderTokens(tokens.filter(token => token.type != 'product'));
+  var product = renderTokens(tokens.filter(token => token.type == 'product'));
+  return `<th>${quantity}</th><td>${product}</td>`;
 }
 
 function renderToken(token) {

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -1,6 +1,7 @@
 import 'jquery';
 import * as moment from 'moment';
 import 'tablesaw/dist/stackonly/tablesaw.stackonly.jquery.js';
+import 'convert-units';
 
 import 'tablesaw/dist/stackonly/tablesaw.stackonly.css';
 import './recipe-list.css'

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -37,13 +37,14 @@ function renderIngredients(tokens) {
     };
   });
   if (collectedTokens.product && collectedTokens.quantity && collectedTokens.units) {
-    return renderIngredient({
+    var ingredient = renderIngredient({
       product: collectedTokens.product,
       quantity: {
         magnitude: collectedTokens.quantity,
         units: collectedTokens.units
       }
     });
+    return `<th>${ingredient.quantity.magnitude} ${ingredient.quantity.units}</th><td>${ingredient.product}</td>`
   }
 
   var quantity = renderTokens(tokens.filter(token => token.type != 'product'));

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -36,7 +36,7 @@ function renderIngredients(tokens) {
       state: token.state,
     };
   });
-  if (collectedTokens.product && collectedTokens.quantity && collectedTokens.units) {
+  if (collectedTokens.product && collectedTokens.units) {
     var ingredient = renderIngredient({
       product: collectedTokens.product,
       quantity: {
@@ -44,7 +44,7 @@ function renderIngredients(tokens) {
         units: collectedTokens.units
       }
     });
-    return `<div class="quantity">${ingredient.quantity.magnitude} ${ingredient.quantity.units}</div><div class="product">${ingredient.product}</div>`
+    return `<div class="quantity">${ingredient.quantity.magnitude || ''} ${ingredient.quantity.units}</div><div class="product">${ingredient.product}</div>`.trim();
   }
 
   var quantity = renderTokens(tokens.filter(token => token.type != 'product'));

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -45,7 +45,8 @@ function renderIngredients(tokens) {
       }
     });
   }
-  return renderTokens(tokens);
+  var renderedIngredient = renderTokens(tokens);
+  return `<td></td><td>${renderedIngredient}</td>`;
 }
 
 function renderToken(token) {
@@ -121,9 +122,9 @@ function contentFormatter(recipe) {
   content.append(tabs);
 
   var ingredients = $('<div />', {'class': 'tab ingredients'});
-  var ingredientList = $('<ul />');
+  var ingredientList = $('<table />');
   $.each(recipe.ingredients, function() {
-    ingredientList.append($('<li />', {'html': renderIngredients(this.tokens)}));
+    ingredientList.append($('<tr />', {'html': renderIngredients(this.tokens)}));
   });
   ingredients.append(ingredientList);
   ingredients.append($('<button />', {

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -4,7 +4,6 @@ import 'select2';
 import 'select2/dist/css/select2.css';
 import './shopping-list.css';
 
-import { float2rat } from '../common';
 import { renderQuantity } from '../conversion';
 import { storage } from '../storage';
 import { addProduct, aggregateUnitQuantities, removeProduct } from '../models/products';

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -18,7 +18,7 @@ function renderProductText(product, mealCounts) {
       magnitude: unitQuantities[unit],
       units: unit
     });
-    productText += `${quantity.magnitude} ${quantity.units}`;
+    productText += `${quantity.magnitude || ''} ${quantity.units}`.trim();
   });
   productText += ' ' + product.product;
   return productText;

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -5,6 +5,7 @@ import 'select2/dist/css/select2.css';
 import './shopping-list.css';
 
 import { float2rat } from '../common';
+import { renderQuantity } from '../conversion';
 import { storage } from '../storage';
 import { addProduct, aggregateUnitQuantities, removeProduct } from '../models/products';
 
@@ -13,7 +14,11 @@ function renderProductText(product, mealCounts) {
   var productText = '';
   $.each(unitQuantities, function(unit) {
     if (productText) productText += ' + ';
-    productText += float2rat(unitQuantities[unit]) + ' ' + unit;
+    var ingredient = renderQuantity({
+      magnitude: unitQuantities[unit],
+      units: unit
+    });
+    productText += `${ingredient.quantity.magnitude} ${ingredient.quantity.units}`;
   });
   productText += ' ' + product.product;
   return productText;

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -14,11 +14,11 @@ function renderProductText(product, mealCounts) {
   var productText = '';
   $.each(unitQuantities, function(unit) {
     if (productText) productText += ' + ';
-    var ingredient = renderQuantity({
+    var quantity = renderQuantity({
       magnitude: unitQuantities[unit],
       units: unit
     });
-    productText += `${ingredient.quantity.magnitude} ${ingredient.quantity.units}`;
+    productText += `${quantity.magnitude} ${quantity.units}`;
   });
   productText += ' ' + product.product;
   return productText;

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -6,22 +6,27 @@ function fraction(nominator, denominator) {
   return `<sup>${nominator}</sup>&frasl;<sub>${denominator}</sub>`;
 }
 
+function renderQuantityHelper(quantity) {
+  var rendered = renderQuantity(quantity);
+  return `${rendered.magnitude} ${rendered.units}`;
+}
+
 describe('unit conversion', function() {
 
   describe('liquids', function() {
 
     it('renders small volumes', function() {
-      var rendered = renderQuantity({magnitude: 10, units: 'ml'});
+      var rendered = renderQuantityHelper({magnitude: 10, units: 'ml'});
       assert.equal(`2 teaspoons`, rendered);
     });
 
     it('renders mid-size volumes', function() {
-      var rendered = renderQuantity({magnitude: 50, units: 'ml'});
+      var rendered = renderQuantityHelper({magnitude: 50, units: 'ml'});
       assert.equal('50 ml', rendered);
     });
 
     it('renders large volumes', function() {
-      var rendered = renderQuantity({magnitude: 1500, units: 'ml'});
+      var rendered = renderQuantityHelper({magnitude: 1500, units: 'ml'});
       assert.equal('1.5 l', rendered);
     });
 
@@ -30,12 +35,12 @@ describe('unit conversion', function() {
   describe('weights', function() {
 
     it('renders mid-size weights', function() {
-      var rendered = renderQuantity({magnitude: 50, units: 'g'});
+      var rendered = renderQuantityHelper({magnitude: 50, units: 'g'});
       assert.equal('50 g', rendered);
     });
 
     it('renders large weights', function() {
-      var rendered = renderQuantity({magnitude: 1500, units: 'g'});
+      var rendered = renderQuantityHelper({magnitude: 1500, units: 'g'});
       assert.equal('1.5 kg', rendered);
     });
 
@@ -44,17 +49,17 @@ describe('unit conversion', function() {
   describe('rounding', function() {
 
     it('leaves small quantities unmodified', function() {
-      var rendered = renderQuantity({magnitude: 3, units: 'g'});
+      var rendered = renderQuantityHelper({magnitude: 3, units: 'g'});
       assert.equal('3 g', rendered);
     });
 
     it('rounds mid-size quantities', function() {
-      var rendered = renderQuantity({magnitude: 63, units: 'g'});
+      var rendered = renderQuantityHelper({magnitude: 63, units: 'g'});
       assert.equal('65 g', rendered);
     });
 
     it('removes precision from large quantities', function() {
-      var rendered = renderQuantity({magnitude: 6005, units: 'g'});
+      var rendered = renderQuantityHelper({magnitude: 6005, units: 'g'});
       assert.equal('6 kg', rendered);
     });
 
@@ -63,13 +68,13 @@ describe('unit conversion', function() {
   describe('plurality', function() {
 
     it('renders less-than-individual measures as singular', function() {
-      var rendered = renderQuantity({magnitude: 2.5, units: 'ml'});
+      var rendered = renderQuantityHelper({magnitude: 2.5, units: 'ml'});
       var expectedFraction = fraction(1, 2);
       assert.equal(`${expectedFraction} teaspoon`, rendered);
     });
 
     it('renders greater-than-individual measures as plural', function() {
-      var rendered = renderQuantity({magnitude: 20, units: 'ml'});
+      var rendered = renderQuantityHelper({magnitude: 20, units: 'ml'});
       var expectedFraction = fraction(1, 3);
       assert.equal(`1 ${expectedFraction} tablespoons`, rendered);
     });
@@ -79,12 +84,12 @@ describe('unit conversion', function() {
   describe('exceptions', function() {
 
     it('renders non-standardized quantities', function() {
-      var rendered = renderQuantity({magnitude: 1, units: 'clove'});
+      var rendered = renderQuantityHelper({magnitude: 1, units: 'clove'});
       assert.equal('1 clove', rendered);
     });
 
     it('renders units without explicit handling', function() {
-      var rendered = renderQuantity({magnitude: 1, units: 'cm'});
+      var rendered = renderQuantityHelper({magnitude: 1, units: 'cm'});
       assert.equal('1 cm', rendered);
     });
 

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -83,6 +83,11 @@ describe('unit conversion', function() {
       assert.equal('1 clove', rendered);
     });
 
+    it('renders units without explicit handling', function() {
+      var rendered = renderQuantity({magnitude: 1, units: 'cm'});
+      assert.equal('1 cm', rendered);
+    });
+
   });
 
 });

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+import * as convert from 'convert-units';
+
+import { renderQuantity } from '../src/app/conversion';
+
+describe('unit conversion', function() {
+
+  // https://en.wikipedia.org/wiki/Cooking_weights_and_measures
+  // http://www.jsward.com/cooking/style.shtml
+  describe('liquids', function() {
+
+    it('renders small volumes', function() {
+      var quantity = convert(10).from('ml');
+      var rendered = renderQuantity(quantity);
+
+      assert.equal('2/3 Tbs', rendered);
+    });
+
+    it('renders mid-size volumes', function() {
+      var quantity = convert(50).from('ml');
+      var rendered = renderQuantity(quantity);
+
+      assert.equal('50 ml', rendered);
+    });
+
+  });
+
+});

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import * as convert from 'convert-units';
 
 import { renderQuantity } from '../src/app/conversion';
 
@@ -12,24 +11,18 @@ describe('unit conversion', function() {
   describe('liquids', function() {
 
     it('renders small volumes', function() {
-      var quantity = convert(10).from('ml');
-      var rendered = renderQuantity(quantity);
-
+      var rendered = renderQuantity({magnitude: 10, units: 'ml'});
       var expectedFraction = fraction(2, 3);
       assert.equal(`${expectedFraction} tablespoons`, rendered);
     });
 
     it('renders mid-size volumes', function() {
-      var quantity = convert(50).from('ml');
-      var rendered = renderQuantity(quantity);
-
+      var rendered = renderQuantity({magnitude: 50, units: 'ml'});
       assert.equal('50 ml', rendered);
     });
 
     it('renders large volumes', function() {
-      var quantity = convert(1500).from('ml');
-      var rendered = renderQuantity(quantity);
-
+      var rendered = renderQuantity({magnitude: 1500, units: 'ml'});
       assert.equal('1.5 l', rendered);
     });
 
@@ -38,16 +31,12 @@ describe('unit conversion', function() {
   describe('weights', function() {
 
     it('renders mid-size weights', function() {
-      var quantity = convert(50).from('g');
-      var rendered = renderQuantity(quantity);
-
+      var rendered = renderQuantity({magnitude: 50, units: 'g'});
       assert.equal('50 g', rendered);
     });
 
     it('renders large weights', function() {
-      var quantity = convert(1500).from('g');
-      var rendered = renderQuantity(quantity);
-
+      var rendered = renderQuantity({magnitude: 1500, units: 'g'});
       assert.equal('1.5 kg', rendered);
     });
 

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -42,4 +42,13 @@ describe('unit conversion', function() {
 
   });
 
+  describe('exceptions', function() {
+
+    it('renders non-standardized quantities', function() {
+      var rendered = renderQuantity({magnitude: 1, units: 'clove'});
+      assert.equal('1 clove', rendered);
+    });
+
+  });
+
 });

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -37,4 +37,22 @@ describe('unit conversion', function() {
 
   });
 
+  describe('weights', function() {
+
+    it('renders mid-size weights', function() {
+      var quantity = convert(50).from('g');
+      var rendered = renderQuantity(quantity);
+
+      assert.equal('50 g', rendered);
+    });
+
+    it('renders large weights', function() {
+      var quantity = convert(1500).from('g');
+      var rendered = renderQuantity(quantity);
+
+      assert.equal('1.5 kg', rendered);
+    });
+
+  });
+
 });

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 
-import { renderQuantity } from '../src/app/conversion';
+import { renderIngredient } from '../src/app/conversion';
 
 function fraction(nominator, denominator) {
   return `<sup>${nominator}</sup>&frasl;<sub>${denominator}</sub>`;
@@ -11,18 +11,18 @@ describe('unit conversion', function() {
   describe('liquids', function() {
 
     it('renders small volumes', function() {
-      var rendered = renderQuantity({magnitude: 10, units: 'ml'});
+      var rendered = renderIngredient({quantity: 10, units: 'ml'});
       var expectedFraction = fraction(2, 3);
       assert.equal(`${expectedFraction} tablespoons`, rendered);
     });
 
     it('renders mid-size volumes', function() {
-      var rendered = renderQuantity({magnitude: 50, units: 'ml'});
+      var rendered = renderIngredient({quantity: 50, units: 'ml'});
       assert.equal('50 ml', rendered);
     });
 
     it('renders large volumes', function() {
-      var rendered = renderQuantity({magnitude: 1500, units: 'ml'});
+      var rendered = renderIngredient({quantity: 1500, units: 'ml'});
       assert.equal('1.5 l', rendered);
     });
 
@@ -31,12 +31,12 @@ describe('unit conversion', function() {
   describe('weights', function() {
 
     it('renders mid-size weights', function() {
-      var rendered = renderQuantity({magnitude: 50, units: 'g'});
+      var rendered = renderIngredient({quantity: 50, units: 'g'});
       assert.equal('50 g', rendered);
     });
 
     it('renders large weights', function() {
-      var rendered = renderQuantity({magnitude: 1500, units: 'g'});
+      var rendered = renderIngredient({quantity: 1500, units: 'g'});
       assert.equal('1.5 kg', rendered);
     });
 

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -8,12 +8,17 @@ function fraction(nominator, denominator) {
 
 function renderQuantityHelper(quantity) {
   var rendered = renderQuantity(quantity);
-  return `${rendered.magnitude} ${rendered.units}`;
+  return `${rendered.magnitude || ''} ${rendered.units}`.trim();
 }
 
 describe('unit conversion', function() {
 
   describe('liquids', function() {
+
+    it('renders pinch volumes', function() {
+      var rendered = renderQuantityHelper({magnitude: 0.25, units: 'ml'});
+      assert.equal(`pinch`, rendered);
+    });
 
     it('renders small volumes', function() {
       var rendered = renderQuantityHelper({magnitude: 10, units: 'ml'});

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 
-import { renderIngredient } from '../src/app/conversion';
+import { renderQuantity } from '../src/app/conversion';
 
 function fraction(nominator, denominator) {
   return `<sup>${nominator}</sup>&frasl;<sub>${denominator}</sub>`;
@@ -11,18 +11,18 @@ describe('unit conversion', function() {
   describe('liquids', function() {
 
     it('renders small volumes', function() {
-      var rendered = renderIngredient({quantity: 10, units: 'ml'});
+      var rendered = renderQuantity({magnitude: 10, units: 'ml'});
       var expectedFraction = fraction(2, 3);
       assert.equal(`${expectedFraction} tablespoons`, rendered);
     });
 
     it('renders mid-size volumes', function() {
-      var rendered = renderIngredient({quantity: 50, units: 'ml'});
+      var rendered = renderQuantity({magnitude: 50, units: 'ml'});
       assert.equal('50 ml', rendered);
     });
 
     it('renders large volumes', function() {
-      var rendered = renderIngredient({quantity: 1500, units: 'ml'});
+      var rendered = renderQuantity({magnitude: 1500, units: 'ml'});
       assert.equal('1.5 l', rendered);
     });
 
@@ -31,12 +31,12 @@ describe('unit conversion', function() {
   describe('weights', function() {
 
     it('renders mid-size weights', function() {
-      var rendered = renderIngredient({quantity: 50, units: 'g'});
+      var rendered = renderQuantity({magnitude: 50, units: 'g'});
       assert.equal('50 g', rendered);
     });
 
     it('renders large weights', function() {
-      var rendered = renderIngredient({quantity: 1500, units: 'g'});
+      var rendered = renderQuantity({magnitude: 1500, units: 'g'});
       assert.equal('1.5 kg', rendered);
     });
 

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -3,6 +3,10 @@ import * as convert from 'convert-units';
 
 import { renderQuantity } from '../src/app/conversion';
 
+function fraction(nominator, denominator) {
+  return `<sup>${nominator}</sup>&frasl;<sub>${denominator}</sub>`;
+}
+
 describe('unit conversion', function() {
 
   // https://en.wikipedia.org/wiki/Cooking_weights_and_measures
@@ -13,7 +17,8 @@ describe('unit conversion', function() {
       var quantity = convert(10).from('ml');
       var rendered = renderQuantity(quantity);
 
-      assert.equal('2/3 tablespoons', rendered);
+      var expectedFraction = fraction(2, 3);
+      assert.equal(`${expectedFraction} tablespoons`, rendered);
     });
 
     it('renders mid-size volumes', function() {

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -42,6 +42,25 @@ describe('unit conversion', function() {
 
   });
 
+  describe('rounding', function() {
+
+    it('leaves small quantities unmodified', function() {
+      var rendered = renderQuantity({magnitude: 3, units: 'g'});
+      assert.equal('3 g', rendered);
+    });
+
+    it('rounds mid-size quantities', function() {
+      var rendered = renderQuantity({magnitude: 63, units: 'g'});
+      assert.equal('65 g', rendered);
+    });
+
+    it('removes precision from large quantities', function() {
+      var rendered = renderQuantity({magnitude: 6005, units: 'g'});
+      assert.equal('6 kg', rendered);
+    });
+
+  });
+
   describe('exceptions', function() {
 
     it('renders non-standardized quantities', function() {

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -13,7 +13,7 @@ describe('unit conversion', function() {
     it('renders small volumes', function() {
       var rendered = renderQuantity({magnitude: 10, units: 'ml'});
       var expectedFraction = fraction(2, 3);
-      assert.equal(`${expectedFraction} tablespoons`, rendered);
+      assert.equal(`${expectedFraction} tablespoon`, rendered);
     });
 
     it('renders mid-size volumes', function() {
@@ -57,6 +57,22 @@ describe('unit conversion', function() {
     it('removes precision from large quantities', function() {
       var rendered = renderQuantity({magnitude: 6005, units: 'g'});
       assert.equal('6 kg', rendered);
+    });
+
+  });
+
+  describe('plurality', function() {
+
+    it('renders less-than-individual measures as singular', function() {
+      var rendered = renderQuantity({magnitude: 2.5, units: 'ml'});
+      var expectedFraction = fraction(1, 2);
+      assert.equal(`${expectedFraction} teaspoon`, rendered);
+    });
+
+    it('renders greater-than-individual measures as plural', function() {
+      var rendered = renderQuantity({magnitude: 20, units: 'ml'});
+      var expectedFraction = fraction(1, 3);
+      assert.equal(`1 ${expectedFraction} tablespoons`, rendered);
     });
 
   });

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -13,7 +13,7 @@ describe('unit conversion', function() {
       var quantity = convert(10).from('ml');
       var rendered = renderQuantity(quantity);
 
-      assert.equal('2/3 Tbs', rendered);
+      assert.equal('2/3 tablespoons', rendered);
     });
 
     it('renders mid-size volumes', function() {

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -28,6 +28,13 @@ describe('unit conversion', function() {
       assert.equal('50 ml', rendered);
     });
 
+    it('renders large volumes', function() {
+      var quantity = convert(1500).from('ml');
+      var rendered = renderQuantity(quantity);
+
+      assert.equal('1.5 l', rendered);
+    });
+
   });
 
 });

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -12,8 +12,7 @@ describe('unit conversion', function() {
 
     it('renders small volumes', function() {
       var rendered = renderQuantity({magnitude: 10, units: 'ml'});
-      var expectedFraction = fraction(2, 3);
-      assert.equal(`${expectedFraction} tablespoon`, rendered);
+      assert.equal(`2 teaspoons`, rendered);
     });
 
     it('renders mid-size volumes', function() {

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -9,8 +9,6 @@ function fraction(nominator, denominator) {
 
 describe('unit conversion', function() {
 
-  // https://en.wikipedia.org/wiki/Cooking_weights_and_measures
-  // http://www.jsward.com/cooking/style.shtml
   describe('liquids', function() {
 
     it('renders small volumes', function() {


### PR DESCRIPTION
Following https://github.com/openculinary/ingredient-parser/pull/1, ingredient quantities are now represented in 'base units' on each ingredient in the database and search engine.

This changeset includes functionality to render those units in appropriate display formats.

Recipe and ingredient scaling will be handled in a subsequent PR.