### PR TITLE
Fixup: Cannot call function toFixed on undefined

### DIFF
--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -34,6 +34,7 @@ function targetUnits(quantity) {
 }
 
 function renderMagnitude(units, magnitude) {
+  if (!magnitude) return magnitude;
   if (magnitude >= 50) {
     magnitude = magnitude / 5;
     magnitude = Math.round(magnitude) * 5;

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -93,9 +93,9 @@ describe('unit conversion', function() {
       assert.equal('1 clove', rendered);
     });
 
-    it('renders units without explicit handling', function() {
-      var rendered = renderQuantityHelper({magnitude: 1, units: 'cm'});
-      assert.equal('1 cm', rendered);
+    it('renders units with empty magnitude', function() {
+      var rendered = renderQuantityHelper({magnitude: undefined, units: 'in'});
+      assert.equal('in', rendered);
     });
 
   });


### PR DESCRIPTION
This was a scenario in which an ingredient had an empty `quantity.magnitude`.  That's an unusual situation and potentially a bug, but the frontend should handle it gracefully.