### PR TITLE
Boost ingredient dropdown z-index

### DIFF
--- a/src/app/main.css
+++ b/src/app/main.css
@@ -27,6 +27,10 @@ span.select2-dropdown {
   z-index: 1;
 }
 
+span.select2-dropdown--above {
+  z-index: 2000;
+}
+
 span.tag.badge {
   color: black;
   font-size: 13px;


### PR DESCRIPTION
Increase the `z-index` of the ingredient drop-down selection when it is rendering above the `select2` input box.  This makes it visible in front of the application menu bar.

Resolves #20 