### PR TITLE
countly: set require_consent flag to true

### DIFF
--- a/src/countly/index.js
+++ b/src/countly/index.js
@@ -10,6 +10,7 @@ Countly.init({
   app_key: 'cbe9c80e3bae3df51d71ae0fbbfa6498d22c42ca',
   app_version: `${VERSION}`,
   force_post: true,
+  require_consent: true,
   url: countlyURI,
   use_session_cookie: false
 });


### PR DESCRIPTION
Relates to #27 

This effectively renders analytics a no-op for the time being, since no consent dialog is yet implemented.  It may be worth removing the analytics code from the frontend completely depending on how long it takes to add a consent dialog.