### PR TITLE
Add lighthouse-cli application evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.lock
 *.swp
+.lighthouseci
 node_modules
 public

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,8 @@ prebuild: lint tests
 lint:
 	eslint src
 
+score:
+	lhci autorun
+
 tests:
 	mochapack --require setup.js

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,6 +3,7 @@
     "assert": {
       "preset": "lighthouse:recommended",
       "assertions": {
+        "redirects-http": "off",
         "uses-http2": "off"
       }
     },

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,6 +3,7 @@
     "assert": {
       "preset": "lighthouse:recommended",
       "assertions": {
+        "uses-http2": "off"
       }
     },
     "collect": {

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,5 +1,10 @@
 {
   "ci": {
+    "assert": {
+      "preset": "lighthouse:recommended",
+      "assertions": {
+      }
+    },
     "collect": {
       "numberOfRuns": 1,
       "staticDistDir": "public"

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,8 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 1,
+      "staticDistDir": "public"
+    }
+  }
+}

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,6 +3,9 @@
     "assert": {
       "preset": "lighthouse:recommended",
       "assertions": {
+        "aria-required-children": "off",
+        "font-display": "off",
+        "unused-css-rules": "off",
         "redirects-http": "off",
         "uses-http2": "off"
       }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "tablesaw": "^3.1.2"
   },
   "devDependencies": {
+    "@lhci/cli": "0.3.6",
     "browserify": "16.5.0",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^5.0.5",


### PR DESCRIPTION
The [lighthouse-ci](https://github.com/GoogleChrome/lighthouse-ci) tool allows command-line assessment, scoring and upload of accessibility and performance scores.

This changeset adds the command to the list of `make` targets available to check and test the `frontend` application's score during development and deployment lifecycles.