### PR TITLE
Support fractional amount rendering for quantities without units

### DIFF
--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -41,7 +41,7 @@ function renderMagnitude(units, magnitude) {
     magnitude = Number(magnitude.toPrecision(3));
     return magnitude.toFixed();
   }
-  if (expandMeasures.indexOf(units) == -1) {
+  if (units && expandMeasures.indexOf(units) == -1) {
     return magnitude.toFixed(2) / 1;
   }
   var result = float2rat(magnitude);
@@ -84,7 +84,7 @@ function renderQuantity(quantity) {
     fromQuantity = convert(quantity.magnitude).from(quantity.units);
   } catch (e) {
     return {
-      'magnitude': quantity.magnitude,
+      'magnitude': renderMagnitude(quantity.units, quantity.magnitude),
       'units': quantity.units
     };
   }

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -44,7 +44,7 @@ function renderIngredients(tokens) {
         units: collectedTokens.units
       }
     });
-    return `<div class="quantity">${ingredient.quantity.magnitude || ''} ${ingredient.quantity.units}</div><div class="product">${ingredient.product}</div>`.trim();
+    return `<div class="quantity">${ingredient.quantity.magnitude || ''} ${ingredient.quantity.units || ''}</div><div class="product">${ingredient.product}</div>`.trim();
   }
 
   var quantity = renderTokens(tokens.filter(token => token.type != 'product'));

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -18,7 +18,7 @@ function renderProductText(product, mealCounts) {
       magnitude: unitQuantities[unit],
       units: unit
     });
-    productText += `${quantity.magnitude || ''} ${quantity.units}`.trim();
+    productText += `${quantity.magnitude || ''} ${quantity.units || ''}`.trim();
   });
   productText += ' ' + product.product;
   return productText;

--- a/test/conversion.js
+++ b/test/conversion.js
@@ -8,7 +8,7 @@ function fraction(nominator, denominator) {
 
 function renderQuantityHelper(quantity) {
   var rendered = renderQuantity(quantity);
-  return `${rendered.magnitude || ''} ${rendered.units}`.trim();
+  return `${rendered.magnitude || ''} ${rendered.units || ''}`.trim();
 }
 
 describe('unit conversion', function() {
@@ -66,6 +66,16 @@ describe('unit conversion', function() {
     it('removes precision from large quantities', function() {
       var rendered = renderQuantityHelper({magnitude: 6005, units: 'g'});
       assert.equal('6 kg', rendered);
+    });
+
+  });
+
+  describe('fractions', function() {
+
+    it('renders fractional amounts', function() {
+      var rendered = renderQuantityHelper({magnitude: 0.5, units: null});
+      var expectedFraction = fraction(1, 2);
+      assert.equal(expectedFraction, rendered);
     });
 
   });


### PR DESCRIPTION
Two interleaved issues prevented quantities without units (i.e. `0.5 whole onion`) from being rendered as fractions in the shopping list:

* A lookup against the special-case `expandMeasures` set did not account for cases where the lookup key (`units`) was undefined
* The error handling case for a situation where quantity conversion fails did not call the `renderMagnitude` function

This changeset handles these issues and adds more consistent/graceful handling of empty/null `quantity.units` fields.

Resolves #34 