### PR TITLE
Close autosuggest dropdown on enter keypress

### DIFF
--- a/src/app/autosuggest.js
+++ b/src/app/autosuggest.js
@@ -54,6 +54,7 @@ $(function() {
 
   $(document).on('keyup', '.select2-search__field', function (event) {
     if (event.keyCode == 13) {
+      $(event.target).parents('span.select2').prev('select').select2('close');
       $('#search form button').click();
     }
   });


### PR DESCRIPTION
The root cause of issue #42 was that although the user could press the `enter` key to issue a search while their focus was contained within an autosuggest element, `select2` still considered the dropdown menu to be open, and as such it was consuming page click events.

To fix this, invoke `select2:close` explicitly after catching an `enter` keypress from an autosuggest field.

Resolves #42 