### PR TITLE
Remove backwards-compatibility translation of category names to identifiers

### DIFF
--- a/i18n/dev/translation.json
+++ b/i18n/dev/translation.json
@@ -6,7 +6,7 @@
     "dry_goods": "Dry Goods",
     "fruit_and_veg": "Fruit & Vegetables",
     "meat_and_deli": "Meat & Delicatessen",
-    "oil_and_vinegar_and_condiments": "Oil, Vinegar and Condiments",
-    "other": "Other"
+    "null": "Other",
+    "oil_and_vinegar_and_condiments": "Oil, Vinegar and Condiments"
   }
 }

--- a/src/app/views/shopping-list.css
+++ b/src/app/views/shopping-list.css
@@ -23,12 +23,6 @@
 #shopping-list .products fieldset.meat_and_deli { border-color: pink; }
 #shopping-list .products fieldset.oil_and_vinegar_and_condiments { border-color: moccasin; }
 
-/* TODO: backwards compatibility; remove */
-#shopping-list .products fieldset.dry { border-color: khaki; }
-#shopping-list .products fieldset.fruit { border-color: palegreen; }
-#shopping-list .products fieldset.meat { border-color: pink; }
-/* END: backwards compatibility; remove */
-
 #shopping-list .products label {
   display: block;
   width: 240px;

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -25,19 +25,7 @@ function renderProductText(product, mealCounts) {
 }
 
 function categoryElement(category) {
-  // TODO: backwards compatibility; remove
-  switch (category) {
-    case 'Bakery': category = 'bakery'; break;
-    case 'Dairy': category = 'dairy'; break;
-    case 'Dry Goods': category = 'dry_goods'; break;
-    case 'Fruit & Vegetables': category = 'fruit_and_veg'; break;
-    case 'Meat': category = 'meat_and_deli'; break;
-    case 'Oil, Vinegar & Condiments': category = 'oil_and_vinegar_and_condiments'; break;
-    default: category = 'other';
-  }
-  // END: backwards compatibility; remove
-
-  var fieldset = $('<fieldset />', {'class': category.toLowerCase()});
+  var fieldset = $('<fieldset />', {'class': category});
   $('<legend />', {'data-i18n': `categories.${category}`}).appendTo(fieldset);
   return fieldset;
 }


### PR DESCRIPTION
With https://github.com/openculinary/knowledge-graph/pull/18 merged, we will receive category identifiers instead of free-text category descriptions for each product in API responses.

This means we can remove backwards-compatibility code in the application which was designed to support responses containing free-text category names.