### PR TITLE
Filter search-on-enter behaviour in autosuggest fields

### DIFF
--- a/src/app/autosuggest.js
+++ b/src/app/autosuggest.js
@@ -55,7 +55,9 @@ $(function() {
   $(document).on('keyup', '.select2-search__field', function (event) {
     if (event.keyCode == 13) {
       $(event.target).parents('span.select2').prev('select').select2('close');
-      $('#search form button').trigger('click');
+      if ($(event.target).parents('#search form').length) {
+        $('#search form button').trigger('click');
+      }
     }
   });
 })


### PR DESCRIPTION
Only trigger recipe search from autosuggest fields contained inside the recipe search control form.

Fixes #46 