### PR TITLE
Read recipe href from recipe.dst

### DIFF
--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -84,7 +84,7 @@ function titleFormatter(recipe) {
   var title = $('<div />', {'class': 'title'});
   $('<img />', {'src': 'images/domains/' + recipe.domain + '.ico', 'alt':''}).appendTo(title);
   $('<a />', {
-    'href': recipe.src,
+    'href': recipe.dst,
     'text': recipe.title,
     'target': '_blank',
     'rel': 'noreferrer'


### PR DESCRIPTION
With https://github.com/openculinary/api/pull/32 merged, the frontend application should render recipe hyperlinks from the `recipe.dst` field.