### PR TITLE
Remove use of Object.entries, Object.fromEntries

### DIFF
--- a/src/app/storage.js
+++ b/src/app/storage.js
@@ -15,8 +15,9 @@ function populateStorage() {
   $.each(storage, function (model) {
     var stored = window.localStorage.getItem(model);
     stored = JSON.parse(stored) || {}
-    stored = new Map(Object.entries(stored));
-    storage[model].apply(stored);
+    var data = new Map();
+    $.each(stored, key => data.set(key, stored[key]));
+    storage[model].apply(data);
   });
 }
 
@@ -44,8 +45,10 @@ $(function() {
     };
 
     modelStorage.save = function() {
-      var items = Object.fromEntries(modelStorage.state());
-      window.localStorage.setItem(model, JSON.stringify(items));
+      var state = modelStorage.state();
+      var data = {};
+      state.forEach((value, key) => data[key] = value);
+      window.localStorage.setItem(model, JSON.stringify(data));
     };
 
     storage[model] = modelStorage;


### PR DESCRIPTION
At the time of writing, these two functions are not well-supported by Internet Explorer ([ref](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries), [ref](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries)).