### PR TITLE
Switch webpack build to use i18next-gettext-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "file-loader": "^5.0.2",
     "git-revision-webpack-plugin": "^3.0.4",
     "html-webpack-plugin": "^3.2.0",
-    "i18next-po-loader": "^1.0.0",
+    "i18next-gettext-loader": "^1.0.0",
     "jsdom": "^15.2.1",
     "mini-css-extract-plugin": "^0.8.0",
     "mocha": "^6.2.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,7 @@ module.exports = {
                 name: 'locales/[1]/[2].json'
               }
             },
-            {loader: 'i18next-po-loader'}
+            {loader: 'i18next-gettext-loader'}
           ]
         },
         {


### PR DESCRIPTION
This migrates the application's webpack build process to use the [i18next-gettext-loader](https://github.com/openculinary/i18next-gettext-loader) webpack resource loader, which has been forked from [i18next-po-loader](https://github.com/queicherius/i18next-po-loader) and published to NPM.