### PR TITLE
Remove search-on-enter within autosuggest fields

### DIFF
--- a/src/app/autosuggest.js
+++ b/src/app/autosuggest.js
@@ -55,9 +55,6 @@ $(function() {
   $(document).on('keyup', '.select2-search__field', function (event) {
     if (event.keyCode == 13) {
       $(event.target).parents('span.select2').prev('select').select2('close');
-      if ($(event.target).parents('#search form').length) {
-        $('#search form button').trigger('click');
-      }
     }
   });
 })


### PR DESCRIPTION
This behaviour was introduced to allow the user to press the 'enter' key at any point during ingredient entry to run a recipe search.

This isn't hugely intuitive and it is likely easier and more effective to allow entry of multiple ingredients (or equipment items) each separated by an enter keypress.

Relates to #70 