### PR TITLE
Repeat search: scroll to search results

### DIFF
--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -24,7 +24,7 @@ function pushSearch() {
   if (sortChoice) state['sort'] = sortChoice;
 
   var stateHash = decodeURIComponent($.param(state));
-  if (window.location.hash === stateHash) {
+  if (window.location.hash === `#${stateHash}`) {
     scrollToResults('#search');
   } else {
     window.location.hash = stateHash;

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -22,7 +22,13 @@ function pushSearch() {
   })
   var sortChoice = getState().sort;
   if (sortChoice) state['sort'] = sortChoice;
-  window.location.hash = decodeURIComponent($.param(state));
+
+  var stateHash = decodeURIComponent($.param(state));
+  if (window.location.hash === stateHash) {
+    scrollToResults('#search');
+  } else {
+    window.location.hash = stateHash;
+  }
 }
 $('#search form button').on('click', pushSearch);
 


### PR DESCRIPTION
When a user requests a search action that matches the already-existing results on the page, then by-design no search occurs.

However, we should still scroll the user to the top of the search results list so that tapping the search button takes the user to the results they're looking for.

Relates to #81 