### PR TITLE
Ensure that 'search' button always scrolls to recipe results list

### DIFF
--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -232,6 +232,7 @@ function bindPostBody(selector) {
     $(this).find('.content button.add-to-shopping-list').on('click', addRecipe);
     $(this).parents('div.recipe-list').show();
 
+    // If the user is on the page containing this table, scroll it into view
     var state = getState();
     if (`#${state.action}` === selector) {
       scrollToResults(selector);

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -18,7 +18,6 @@ export {
     bindLoadEvent,
     recipeFormatter,
     rowAttributes,
-    scrollToResults,
     updateRecipeState,
     updateStarState,
 };
@@ -232,6 +231,8 @@ function bindPostBody(selector) {
     $(this).find('.content .tabs a.nav-link').on('click', selectTab);
     $(this).find('.content button.add-to-shopping-list').on('click', addRecipe);
     $(this).parents('div.recipe-list').show();
+
+    scrollToResults(selector);
   });
 }
 

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -18,7 +18,6 @@ export {
     bindLoadEvent,
     recipeFormatter,
     rowAttributes,
-    scrollToResults,
     updateRecipeState,
     updateStarState,
 };

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -233,7 +233,10 @@ function bindPostBody(selector) {
     $(this).find('.content button.add-to-shopping-list').on('click', addRecipe);
     $(this).parents('div.recipe-list').show();
 
-    scrollToResults(selector);
+    var state = getState();
+    if (`#${state.action}` === selector) {
+      scrollToResults(selector);
+    }
   });
 }
 

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -18,6 +18,7 @@ export {
     bindLoadEvent,
     recipeFormatter,
     rowAttributes,
+    scrollToResults,
     updateRecipeState,
     updateStarState,
 };

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -7,7 +7,7 @@ import './search.css';
 
 import '../autosuggest';
 import { getState, loadPage, loadState } from '../state';
-import { initTable, bindLoadEvent, scrollToResults } from '../ui/recipe-list';
+import { initTable, bindLoadEvent } from '../ui/recipe-list';
 
 export { renderSearch, renderIndividual };
 
@@ -42,7 +42,6 @@ function renderSearch() {
   });
 
   loadPage('search');
-  scrollToResults('#search');
 }
 
 function renderIndividual() {
@@ -50,7 +49,6 @@ function renderIndividual() {
   $('#search .recipe-list table').bootstrapTable('refresh', {
     url: '/api/recipes/' + encodeURIComponent(id) + '/view'
   });
-  scrollToResults('#search');
 }
 
 function renderRefinement(refinement) {

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -27,9 +27,7 @@ function pushSearch() {
 
   // Simulate a results page change so that results are scrolled into view
   if (window.location.hash === `#${stateHash}`) {
-    var table = $('#search .recipe-list table');
-    var tableData = table.bootstrapTable('getData', {useCurrentPage: true});
-    table.trigger('page-change.bs.table', {data: tableData});
+    $('#search .recipe-list table').first().trigger('page-change.bs.table');
   }
 
   window.location.hash = stateHash;

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -7,7 +7,7 @@ import './search.css';
 
 import '../autosuggest';
 import { getState, loadPage, loadState } from '../state';
-import { initTable, bindLoadEvent, scrollToResults } from '../ui/recipe-list';
+import { initTable, bindLoadEvent } from '../ui/recipe-list';
 
 export { renderSearch, renderIndividual };
 
@@ -24,11 +24,15 @@ function pushSearch() {
   if (sortChoice) state['sort'] = sortChoice;
 
   var stateHash = decodeURIComponent($.param(state));
+
+  // Simulate a results page change so that results are scrolled into view
   if (window.location.hash === `#${stateHash}`) {
-    scrollToResults('#search');
-  } else {
-    window.location.hash = stateHash;
+    var table = $('#search .recipe-list table');
+    var tableData = table.bootstrapTable('getData', {useCurrentPage: true});
+    table.trigger('page-change.bs.table', {data: tableData});
   }
+
+  window.location.hash = stateHash;
 }
 $('#search form button').on('click', pushSearch);
 

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -23,9 +23,9 @@ function pushSearch() {
   var sortChoice = getState().sort;
   if (sortChoice) state['sort'] = sortChoice;
 
+  // If the requested search is a repeat of the current state, perform a results refresh
+  // This is done to ensure that the results are scrolled into view
   var stateHash = decodeURIComponent($.param(state));
-
-  // Simulate a results page change so that results are scrolled into view
   if (window.location.hash === `#${stateHash}`) {
     $('#search .recipe-list table').first().trigger('page-change.bs.table');
   }

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -7,7 +7,7 @@ import './search.css';
 
 import '../autosuggest';
 import { getState, loadPage, loadState } from '../state';
-import { initTable, bindLoadEvent } from '../ui/recipe-list';
+import { initTable, bindLoadEvent, scrollToResults } from '../ui/recipe-list';
 
 export { renderSearch, renderIndividual };
 


### PR DESCRIPTION
This changeset is intended to ensure that search results are always scrolled into view when a user presses the 'search' button.  A backend search query may not be initiated if the search is a duplicate, but the user experience should be that they are taken to their expected results.

This is an improved fix for #47 
Resolves #81 