### PR TITLE
Allow read env.mode if env properties exist

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = (_, env) => { return {
       ]),
       new CopyWebpackPlugin([
         {
-          from: `static/images/icons/${env.mode || 'development'}/*`,
+          from: `static/images/icons/${env && env.mode || 'development'}/*`,
           to: 'images/icons',
           flatten: true
         }


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Resolves #96 

### Briefly summarize the changes
1. Only read `env.mode` when `env` configuration is populated

### How have the changes been tested?
1. Locally via `npx make build`