### PR TITLE
Remove mochapack warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ lint:
 	eslint src
 
 tests:
-	mochapack --require setup.js
+	mochapack --mode development --require setup.js

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 .PHONY: build-dev build lint tests
 
+MODE = 'development'
+build : MODE = 'production'
+
 build-dev:
-	webpack
+	webpack --mode ${MODE}
 
 build: lint tests
-	webpack --mode production --optimize-minimize
+	webpack --mode ${MODE} --optimize-minimize
 
 lint:
 	eslint src
 
 tests:
-	mochapack --mode development --require setup.js
+	mochapack --mode ${MODE} --require setup.js

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build-dev:
 	webpack
 
 build: lint tests
-	webpack -p
+	webpack --mode production --optimize-minimize
 
 lint:
 	eslint src


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Resolves #100 

### Briefly summarize the changes
1. Always provide an environment-specific `mode` flag to invocation of `mochapack`
1. (fix-unrelated) Improve `webpack` mode handling by providing the same `mode` flag there too

### How have the changes been tested?
1. Locally via `npx make tests`