### PR TITLE
Improve resilience of refinement rendering

### DIFF
--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -84,12 +84,14 @@ function emptyResultHandler(data) {
 }
 
 function refinementHandler(data) {
-  var refinements = $('#search .refinements');
-  refinements.empty();
+  // Produce an array containing refinements that can be rendered
   data.refinements = data.refinements || [];
-  data.refinements.forEach(function(refinement) {
-    refinements.append(renderRefinement(refinement));
-  });
+  data.refinements = data.refinements.map(renderRefinement);
+  data.refinements = data.refinements.filter(refinement => refinement);
+
+  // Show or hide the list of refinements in the user interface
+  var refinements = $('#search .refinements').empty();
+  data.refinements.map(refinement => refinements.append(refinement));
   refinements.toggleClass('collapse', data.refinements.length == 0);
 }
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This is a resilience improvement for the rendering of refinements returned by the RecipeRadar API.

In situations where an individual refinement tag is unknown to the application and cannot be rendered, the refinement will now be ignored rather than incorrectly appended as a `null` entry.

### Briefly summarize the changes
1. Filter non-null refinements from the list rendered in the user interface

### How have the changes been tested?
1. Minimal manual testing so far
