### PR TITLE
Add refinement support: refinement-empty-query

### DIFF
--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -61,6 +61,11 @@ function renderIndividual() {
 }
 
 function renderRefinement(refinement) {
+  if (refinement == 'empty_query') {
+    return $('<div />', {
+      'data-i18n': '[html]search:refinement-empty-query'
+    });
+  }
   if (refinement == 'match_any') {
     return $('<div />', {
       'data-i18n': '[html]search:refinement-partial-results'


### PR DESCRIPTION
### Briefly summarize the changes
1. Render the `refinement-empty-query` resource string when a search includes the `empty_query` refinement response

**List any issues that this change relates to**
Relates to https://github.com/openculinary/frontend/issues/70
Implements support for https://github.com/openculinary/api/pull/40
Uses resources from https://github.com/openculinary/internationalization/pull/11
