### PR TITLE
Autosuggest search on enter

### DIFF
--- a/src/app/autosuggest.js
+++ b/src/app/autosuggest.js
@@ -53,11 +53,17 @@ $(function() {
   bindEquipmentInput('#equipment', 'Kitchen equipment to use', 'e.g. slow cooker');
 
   $(document).on('keyup', '.select2-search__field', function (event) {
-    if (event.keyCode == 13) {
-      $(event.target).parents('span.select2').prev('select').select2('close');
-      if ($(event.target).parents('#search form').length) {
-        $('#search form button').trigger('click');
-      }
+    if (event.which == 13) {
+      var selectElement = $(event.target).parents('span.select2').prev('select');
+      if (!selectElement.length) return;
+
+      var searchForm = selectElement.parents('#search form');
+      if (!searchForm.length) return;
+
+      var suggestionsOpen = !selectElement.select2('isOpen');
+      if (suggestionsOpen) return;
+
+      $('#search form button').trigger('click');
     }
   });
 })

--- a/src/app/autosuggest.js
+++ b/src/app/autosuggest.js
@@ -55,6 +55,9 @@ $(function() {
   $(document).on('keyup', '.select2-search__field', function (event) {
     if (event.keyCode == 13) {
       $(event.target).parents('span.select2').prev('select').select2('close');
+      if ($(event.target).parents('#search form').length) {
+        $('#search form button').trigger('click');
+      }
     }
   });
 })


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This change alters the behaviour of enter keypresses within search autosuggest elements in the application.

If the autosuggest element is displaying a drop-down selection list, then pressing enter will close the list and select the currently-highlighted item.

If the autosuggest is not displaying a selection list, pressing enter will initiate a recipe search.

### Briefly summarize the changes
1. Detect the autosuggest drop-down selection state
1. Perform a search if the drop-down list is closed when the keypress occurred

### How have the changes been tested?
1. Local testing via a development instances

**List any issues that this change relates to**
Fixes #82 
Relates to #70 
