### PR TITLE
Draw a line through ingredients removed from search

### DIFF
--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -73,7 +73,7 @@ function renderRefinement(refinement) {
   }
   if (refinement.startsWith('removed:')) {
     var product = refinement.split(':')[1];
-    $(`#search .include span.tag.badge:contains('${product}')`).css('background-color', 'silver');
+    $('#include').next('.select2').find(`li[title~='${product}']`).css('text-decoration', 'line-through');
     return $('<div />', {
       'data-i18n': '[html]search:refinement-ingredient-removed',
       'data-i18n-options': JSON.stringify({product: product})


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
When performing a search-by-ingredients, the API may choose to modify the search to drop ingredient(s) in order to return more results to the user.

The application should display the removed ingredients differently to visually aid the user when they're deciding how to proceed with further searches.

### Briefly summarize the changes
1. Draw a line through ingredients that were removed from the search query

### How have the changes been tested?
1. Locally via a development instance of the application

**List any issues that this change relates to**
Fixes #107 
Relates to #70 
