### PR TITLE
Fixup: prevent aria-labels from being clobbered

### DIFF
--- a/src/app/autosuggest.js
+++ b/src/app/autosuggest.js
@@ -22,7 +22,7 @@ function bindEquipmentInput(element, label, placeholder) {
   });
 
   // TODO: Revisit once https://github.com/select2/select2/issues/3744 is handled
-  $(element).siblings('.select2').find('input[type=search]').attr('aria-label', label);
+  $(element).next('.select2').find('input[type=search]').attr('aria-label', label);
 }
 
 function bindIngredientInput(element, label, placeholder) {
@@ -44,7 +44,7 @@ function bindIngredientInput(element, label, placeholder) {
   });
 
   // TODO: Revisit once https://github.com/select2/select2/issues/3744 is handled
-  $(element).siblings('.select2').find('input[type=search]').attr('aria-label', label);
+  $(element).next('.select2').find('input[type=search]').attr('aria-label', label);
 }
 
 $(function() {


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The element selection rules for `select2` ARIA label assignment were not strict enough, leading to the last element's label to be applied overwriting any existing previous element labels.

### Briefly summarize the changes
1. Tighten the definition of the label application rules

### How have the changes been tested?
1. Tested locally via a development instance of the application
