### PR TITLE
Handle state changes via browser History API

### DIFF
--- a/src/app/main.js
+++ b/src/app/main.js
@@ -2,7 +2,6 @@ import '@fortawesome/fontawesome-free/css/fontawesome.min.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 
 import './dialogs/about';
-import './state';
 import './views/search';
 import './views/starred';
 import './views/meals';

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -2,6 +2,7 @@ import '@fortawesome/fontawesome-free/css/fontawesome.min.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 
 import './dialogs/about';
+import './state';
 import './views/search';
 import './views/starred';
 import './views/meals';

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -14,7 +14,9 @@ function getState() {
 }
 
 function pushState(state, hash) {
+  if (window.location.hash === hash) return;
   history.pushState(state, '', hash);
+  $(window).trigger('hashchange');
 }
 
 function loadTags(element, data) {

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -2,7 +2,7 @@ import 'jquery';
 
 import { renderSearch, renderIndividual } from './views/search';
 
-export { getState, loadPage, loadState, pushState };
+export { getState, loadPage, pushState };
 
 function getState() {
   var state = {};

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -72,7 +72,7 @@ $(function() {
     var tabName = $(e.target).attr('href').substr(1);
     state[tabName] = null;
 
-    var stateHash = decodeURIComponent($.param(state));
+    var stateHash = decodeURIComponent($.param(state)).slice(0, -1);
     pushState(state, `#${stateHash}`);
   });
 

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -68,6 +68,10 @@ function loadState() {
 
 $(function() {
   $('#about-modal a').on('shown.bs.tab', function (e) {
-    pushState(e.target.hash);
+    var href = $(e.target).attr('href');
+    var state = {href: null};
+
+    var stateHash = decodeURIComponent($.param(state));
+    pushState(`#${stateHash}`);
   });
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -14,7 +14,7 @@ function getState() {
 }
 
 function pushState(state, hash) {
-  history.pushState(state, null, hash);
+  history.pushState(state, '', hash);
 }
 
 function loadTags(element, data) {

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -69,7 +69,7 @@ function loadState() {
 $(function() {
   $('#about-modal a').on('shown.bs.tab', function (e) {
     var state = {};
-    var tabName = $(e.target).attr('href');
+    var tabName = $(e.target).attr('href').substr(1);
     state[tabName] = null;
 
     var stateHash = decodeURIComponent($.param(state));

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -5,7 +5,7 @@ import { renderSearch, renderIndividual } from './views/search';
 export { getState, pushState };
 
 function getState() {
-  return history.state;
+  return history.state || {};
 }
 
 function pushState(state, hash) {
@@ -49,7 +49,7 @@ function loadState() {
 
   // If we encounter an empty state, display the homepage
   var state = getState();
-  if (!state || Object.keys(state).length === 0) {
+  if (Object.keys(state).length === 0) {
     loadPage('search');
     return;
   }
@@ -78,7 +78,6 @@ $(function() {
     pushState(state, `#${stateHash}`);
   });
 
-  pushState({}, '');
   window.onpopstate = loadState;
   loadState();
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -69,6 +69,10 @@ function loadState() {
 }
 
 $(function() {
+  $('#about-modal a').on('shown.bs.tab', function (e) {
+    pushState(null, e.target.hash);
+  });
+
   window.onpopstate = loadState;
   loadState();
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -44,7 +44,7 @@ function loadState() {
   // If we encounter an empty state, display the homepage
   var state = getState();
   var urlParams = new URLSearchParams(window.location.hash.slice(1));
-  if (Object.keys(state).length === 0 && !urlParams.keys().next()) {
+  if (Object.keys(state).length === 0 && urlParams.keys().next().done) {
     urlParams.set('search', null);
   }
 

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -67,6 +67,6 @@ $(function() {
   });
 
   window.history.pushState({}, '', '');
-  $(window).on('popstate', loadState);
+  window.onpopstate = loadState;
   loadState();
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -41,15 +41,10 @@ function loadAboutTab(tabId) {
 }
 
 function loadState() {
-  // Load any 'about' pages specified in the URL
-  var urlParams = new URLSearchParams(window.location.hash.slice(1));
-  $('#about-modal div.tab-pane[id]').each(function() {
-    if (urlParams.has(this.id)) loadAboutTab(this.id);
-  });
-
   // If we encounter an empty state, display the homepage
   var state = getState();
-  if (Object.keys(state).length === 0) {
+  var urlParams = new URLSearchParams(window.location.hash.slice(1));
+  if (Object.keys(state).length === 0 && urlParams.entries.length === 0) {
     loadPage('search');
     return;
   }
@@ -59,7 +54,11 @@ function loadState() {
   loadTags('#equipment', state.equipment);
 
   $('body > div.container[id]').each(function() {
-    if (this.id in state) loadPage(this.id);
+    if (urlParams.has(this.id)) loadPage(this.id);
+  });
+
+  $('#about-modal div.tab-pane[id]').each(function() {
+    if (urlParams.has(this.id)) loadAboutTab(this.id);
   });
 
   switch (state.action) {

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -75,7 +75,6 @@ $(function() {
     pushState(state, `#${stateHash}`);
   });
 
-  $(window).on('hashchange', loadState);
   $(window).on('popstate', loadState);
   loadState();
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -31,7 +31,7 @@ function loadAboutTab(tabId) {
 }
 
 function loadState() {
-  var state = window.history.state;
+  var state = history.state;
 
   loadTags('#include', state.include);
   loadTags('#exclude', state.exclude);

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -68,8 +68,9 @@ function loadState() {
 
 $(function() {
   $('#about-modal a').on('shown.bs.tab', function (e) {
-    var href = $(e.target).attr('href');
-    var state = {href: null};
+    var state = {};
+    var tabName = $(e.target).attr('href');
+    state[tabName] = null;
 
     var stateHash = decodeURIComponent($.param(state));
     pushState(state, `#${stateHash}`);

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -2,21 +2,7 @@ import 'jquery';
 
 import { renderSearch, renderIndividual } from './views/search';
 
-export { getState, loadPage, pushState };
-
-function getState() {
-  if (window.history.state) return window.history.state;
-  var state = {};
-  var urlParams = new URLSearchParams(window.location.hash.slice(1));
-  urlParams.forEach(function(value, key) {
-    state[key] = value;
-  })
-  return state;
-}
-
-function pushState(state, hash) {
-  history.pushState(state, '', hash);
-}
+export { loadPage };
 
 function loadTags(element, data) {
   var tags = $(element).val();
@@ -47,7 +33,7 @@ function loadAboutTab(tabId) {
 }
 
 function loadState() {
-  var state = getState();
+  var state = window.history.state;
 
   loadTags('#include', state.include);
   loadTags('#exclude', state.exclude);
@@ -77,7 +63,7 @@ $(function() {
     state[tabName] = null;
 
     var stateHash = decodeURIComponent($.param(state)).slice(0, -1);
-    pushState(state, `#${stateHash}`);
+    window.history.pushState(state, '', `#${stateHash}`);
   });
 
   $(window).on('popstate', loadState);

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -2,6 +2,16 @@ import 'jquery';
 
 import { renderSearch, renderIndividual } from './views/search';
 
+export { getState, pushState };
+
+function getState() {
+  return history.state;
+}
+
+function pushState(state, hash) {
+  history.pushState(state, '', hash);
+}
+
 function loadTags(element, data) {
   var tags = $(element).val();
   var terms = data ? data.split(',') : [];
@@ -31,7 +41,7 @@ function loadAboutTab(tabId) {
 }
 
 function loadState() {
-  var state = history.state;
+  var state = getState();
 
   loadTags('#include', state.include);
   loadTags('#exclude', state.exclude);
@@ -45,6 +55,7 @@ function loadState() {
     if (this.id in state) loadAboutTab(this.id);
   });
 
+  // Render the homepage if the state is empty
   if (Object.keys(state).length === 0) {
     loadPage('search');
   }
@@ -61,10 +72,10 @@ $(function() {
     state[tabName] = null;
 
     var stateHash = decodeURIComponent($.param(state)).slice(0, -1);
-    window.history.pushState(state, '', `#${stateHash}`);
+    pushState(state, `#${stateHash}`);
   });
 
-  window.history.pushState({}, '', '');
+  pushState({}, '');
   window.onpopstate = loadState;
   loadState();
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -26,8 +26,6 @@ function loadTags(element, data) {
 }
 
 function loadPage(pageId) {
-  $('#about-modal').modal('hide');
-
   $('body > div.container[id]').hide();
   $(`body > div.container[id="${pageId}"]`).show();
 

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -43,6 +43,12 @@ function loadAboutTab(tabId) {
 function loadState() {
   var state = getState();
 
+  // If we encounter an empty state, display the homepage
+  if (!state || Object.keys(state).length === 0) {
+    loadPage('search');
+    return;
+  }
+
   loadTags('#include', state.include);
   loadTags('#exclude', state.exclude);
   loadTags('#equipment', state.equipment);
@@ -55,10 +61,6 @@ function loadState() {
     if (this.id in state) loadAboutTab(this.id);
   });
 
-  // Render the homepage if the state is empty
-  if (Object.keys(state).length === 0) {
-    loadPage('search');
-  }
   switch (state.action) {
     case 'search': renderSearch(); break;
     case 'view': renderIndividual(); break;

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -14,9 +14,7 @@ function getState() {
 }
 
 function pushState(state, hash) {
-  if (window.location.hash === hash) return;
   history.pushState(state, '', hash);
-  loadState();
 }
 
 function loadTags(element, data) {

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -72,6 +72,10 @@ function loadState() {
 }
 
 $(function() {
+  $('#about-modal a').on('shown.bs.tab', function (e) {
+    window.location.hash = e.target.hash;
+  });
+
   window.onpopstate = loadState;
   loadState();
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -13,6 +13,10 @@ function getState() {
   return state;
 }
 
+function pushState(hash) {
+  history.pushState(null, null, hash);
+}
+
 function loadTags(element, data) {
   if (!data) return;
   var tags = $(element).val();
@@ -64,6 +68,6 @@ function loadState() {
 
 $(function() {
   $('#about-modal a').on('shown.bs.tab', function (e) {
-    history.pushState(null, null, e.target.hash);
+    pushState(e.target.hash);
   });
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -69,12 +69,7 @@ function loadState() {
 
 $(function() {
   $('#about-modal a').on('shown.bs.tab', function (e) {
-    var state = {};
-    var tabName = $(e.target).attr('href').substr(1);
-    state[tabName] = null;
-
-    var stateHash = decodeURIComponent($.param(state)).slice(0, -1);
-    pushState(state, `#${stateHash}`);
+    pushState(null, e.target.hash);
   });
 
   window.onpopstate = loadState;

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -60,6 +60,7 @@ function loadState() {
     if (urlParams.has(this.id)) loadAboutTab(this.id);
   });
 
+  if (state.action) $('.modal.show').modal('hide');
   switch (state.action) {
     case 'search': renderSearch(); break;
     case 'view': renderIndividual(); break;

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -76,4 +76,7 @@ $(function() {
     var stateHash = decodeURIComponent($.param(state));
     pushState(state, `#${stateHash}`);
   });
+
+  window.onhashchange = loadState;
+  loadState();
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -72,10 +72,6 @@ function loadState() {
 }
 
 $(function() {
-  $('#about-modal a').on('shown.bs.tab', function (e) {
-    pushState(null, e.target.hash);
-  });
-
   window.onpopstate = loadState;
   loadState();
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -26,6 +26,8 @@ function loadTags(element, data) {
 }
 
 function loadPage(pageId) {
+  $('#about-modal').modal('hide');
+
   $('body > div.container[id]').hide();
   $(`body > div.container[id="${pageId}"]`).show();
 

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -16,7 +16,7 @@ function getState() {
 function pushState(state, hash) {
   if (window.location.hash === hash) return;
   history.pushState(state, '', hash);
-  $(window).trigger('hashchange');
+  loadState();
 }
 
 function loadTags(element, data) {
@@ -77,6 +77,5 @@ $(function() {
     pushState(state, `#${stateHash}`);
   });
 
-  window.onhashchange = loadState;
   loadState();
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -13,8 +13,8 @@ function getState() {
   return state;
 }
 
-function pushState(hash) {
-  history.pushState(null, null, hash);
+function pushState(state, hash) {
+  history.pushState(state, null, hash);
 }
 
 function loadTags(element, data) {
@@ -72,6 +72,6 @@ $(function() {
     var state = {href: null};
 
     var stateHash = decodeURIComponent($.param(state));
-    pushState(`#${stateHash}`);
+    pushState(state, `#${stateHash}`);
   });
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -73,7 +73,7 @@ function loadState() {
 
 $(function() {
   $('#about-modal a').on('shown.bs.tab', function (e) {
-    window.location.hash = e.target.hash;
+    pushState(getState(), e.target.hash);
   });
 
   window.onpopstate = loadState;

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -37,6 +37,8 @@ function loadPage(pageId) {
 
   $('header a').removeClass('active');
   $('header a[href="#' + pageId + '"]').addClass('active');
+
+  $(window).animate({scrollTop: 0}, 50);
 }
 
 function loadAboutTab(tabId) {
@@ -59,8 +61,10 @@ function loadState() {
     if (this.id in state) loadAboutTab(this.id);
   });
 
-  var action = state.action;
-  switch (action) {
+  if (Object.keys(state).length === 0) {
+    loadPage('search');
+  }
+  switch (state.action) {
     case 'search': renderSearch(); break;
     case 'view': renderIndividual(); break;
   }

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -68,10 +68,6 @@ function loadState() {
 }
 
 $(function() {
-  $('#about-modal a').on('shown.bs.tab', function (e) {
-    pushState(null, e.target.hash);
-  });
-
   window.onpopstate = loadState;
   loadState();
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -63,11 +63,14 @@ function loadState() {
   var activeTab = $('.modal.show a.active').attr('href');
   if (activeTab && !urlParams.has(activeTab.slice(1))) {
     $('.modal.show').modal('hide');
+    activeTab = null;
   }
 
-  switch (state.action) {
-    case 'search': renderSearch(); break;
-    case 'view': renderIndividual(); break;
+  if (!activeTab) {
+    switch (state.action) {
+      case 'search': renderSearch(); break;
+      case 'view': renderIndividual(); break;
+    }
   }
 }
 

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -48,11 +48,6 @@ function loadState() {
     urlParams.set('search', null);
   }
 
-  var activeTab = $('.modal.show a.active').attr('href');
-  if (activeTab && !urlParams.has(activeTab.slice(1))) {
-    $('.modal.show').modal('hide');
-  }
-
   loadTags('#include', state.include);
   loadTags('#exclude', state.exclude);
   loadTags('#equipment', state.equipment);
@@ -64,6 +59,11 @@ function loadState() {
   $('#about-modal div.tab-pane[id]').each(function() {
     if (urlParams.has(this.id)) loadAboutTab(this.id);
   });
+
+  var activeTab = $('.modal.show a.active').attr('href');
+  if (activeTab && !urlParams.has(activeTab.slice(1))) {
+    $('.modal.show').modal('hide');
+  }
 
   switch (state.action) {
     case 'search': renderSearch(); break;

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -18,9 +18,8 @@ function pushState(state, hash) {
 }
 
 function loadTags(element, data) {
-  if (!data) return;
   var tags = $(element).val();
-  var terms = data.split(',');
+  var terms = data ? data.split(',') : [];
   tags.forEach(function(tag) {
     if (terms.indexOf(tag) >= 0) return;
     $(element).find(`option[value='${tag}']`).remove();

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -77,6 +77,7 @@ $(function() {
     pushState(state, `#${stateHash}`);
   });
 
+  $(window).on('hashchange', loadState);
   $(window).on('popstate', loadState);
   loadState();
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -66,6 +66,7 @@ $(function() {
     window.history.pushState(state, '', `#${stateHash}`);
   });
 
+  window.history.pushState({}, '', '');
   $(window).on('popstate', loadState);
   loadState();
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -44,7 +44,7 @@ function loadState() {
   // If we encounter an empty state, display the homepage
   var state = getState();
   var urlParams = new URLSearchParams(window.location.hash.slice(1));
-  if (Object.keys(state).length === 0 && urlParams.entries.length === 0) {
+  if (Object.keys(state).length === 0 && !urlParams.keys().next()) {
     loadPage('search');
     return;
   }

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -2,7 +2,7 @@ import 'jquery';
 
 import { renderSearch, renderIndividual } from './views/search';
 
-export { getState, loadPage, loadState };
+export { getState, loadPage, loadState, pushState };
 
 function getState() {
   var state = {};

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -2,8 +2,6 @@ import 'jquery';
 
 import { renderSearch, renderIndividual } from './views/search';
 
-export { loadPage };
-
 function loadTags(element, data) {
   var tags = $(element).val();
   var terms = data ? data.split(',') : [];

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -5,6 +5,7 @@ import { renderSearch, renderIndividual } from './views/search';
 export { getState, loadPage, pushState };
 
 function getState() {
+  if (window.history.state) return window.history.state;
   var state = {};
   var urlParams = new URLSearchParams(window.location.hash.slice(1));
   urlParams.forEach(function(value, key) {

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -47,8 +47,7 @@ function loadState() {
   var state = getState();
   var urlParams = new URLSearchParams(window.location.hash.slice(1));
   if (Object.keys(state).length === 0 && !urlParams.keys().next()) {
-    loadPage('search');
-    return;
+    urlParams.set('search', null);
   }
 
   loadTags('#include', state.include);

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -41,9 +41,14 @@ function loadAboutTab(tabId) {
 }
 
 function loadState() {
-  var state = getState();
+  // Load any 'about' pages specified in the URL
+  var urlParams = new URLSearchParams(window.location.hash.slice(1));
+  $('#about-modal div.tab-pane[id]').each(function() {
+    if (urlParams.has(this.id)) loadAboutTab(this.id);
+  });
 
   // If we encounter an empty state, display the homepage
+  var state = getState();
   if (!state || Object.keys(state).length === 0) {
     loadPage('search');
     return;
@@ -55,10 +60,6 @@ function loadState() {
 
   $('body > div.container[id]').each(function() {
     if (this.id in state) loadPage(this.id);
-  });
-
-  $('#about-modal div.tab-pane[id]').each(function() {
-    if (this.id in state) loadAboutTab(this.id);
   });
 
   switch (state.action) {

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -77,5 +77,6 @@ $(function() {
     pushState(state, `#${stateHash}`);
   });
 
+  $(window).on('popstate', loadState);
   loadState();
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -48,6 +48,11 @@ function loadState() {
     urlParams.set('search', null);
   }
 
+  var activeTab = $('.modal.show a.active').attr('href');
+  if (activeTab && !urlParams.has(activeTab.slice(1))) {
+    $('.modal.show').modal('hide');
+  }
+
   loadTags('#include', state.include);
   loadTags('#exclude', state.exclude);
   loadTags('#equipment', state.equipment);
@@ -60,7 +65,6 @@ function loadState() {
     if (urlParams.has(this.id)) loadAboutTab(this.id);
   });
 
-  if (state.action) $('.modal.show').modal('hide');
   switch (state.action) {
     case 'search': renderSearch(); break;
     case 'view': renderIndividual(); break;

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -8,7 +8,6 @@ import './recipe-list.css'
 
 import { float2rat, getRecipe } from '../common';
 import { renderIngredient } from '../conversion';
-import { getState, pushState } from '../state';
 import { storage } from '../storage';
 import { addRecipe } from '../models/recipes';
 import { starRecipe, unstarRecipe } from '../models/starred';
@@ -179,12 +178,12 @@ function scrollToResults(selector, delay) {
 
 function bindPageChange(selector) {
   $(`${selector} table[data-row-attributes]`).on('page-change.bs.table', function(e, number, size) {
-    var state = getState();
+    var state = window.history.state;
     if (number > 1) state.page = number;
     else delete state.page;
 
     var stateHash = decodeURIComponent($.param(state));
-    pushState(state, `#${stateHash}`);
+    window.history.pushState(state, '', `#${stateHash}`);
 
     scrollToResults(selector, 50);
   });
@@ -235,8 +234,7 @@ function bindPostBody(selector) {
     $(this).parents('div.recipe-list').show();
 
     // If the user is on the page containing this table, scroll it into view
-    var state = getState();
-    if (`#${state.action}` === selector) {
+    if (`#${window.history.state.action}` === selector) {
       scrollToResults(selector);
     }
   });

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -178,7 +178,9 @@ function scrollToResults(selector, delay) {
 
 function bindPageChange(selector) {
   $(`${selector} table[data-row-attributes]`).on('page-change.bs.table', function(e, number, size) {
-    var state = window.history.state;
+    var state = history.state;
+
+    // Write the new page number into the application's state
     if (number > 1) state.page = number;
     else delete state.page;
 
@@ -234,7 +236,7 @@ function bindPostBody(selector) {
     $(this).parents('div.recipe-list').show();
 
     // If the user is on the page containing this table, scroll it into view
-    if (`#${window.history.state.action}` === selector) {
+    if (`#${history.state.action}` === selector) {
       scrollToResults(selector);
     }
   });

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -8,7 +8,7 @@ import './recipe-list.css'
 
 import { float2rat, getRecipe } from '../common';
 import { renderIngredient } from '../conversion';
-import { getState } from '../state';
+import { getState, pushState } from '../state';
 import { storage } from '../storage';
 import { addRecipe } from '../models/recipes';
 import { starRecipe, unstarRecipe } from '../models/starred';
@@ -182,7 +182,9 @@ function bindPageChange(selector) {
     var state = getState();
     if (number > 1) state.page = number;
     else delete state.page;
-    window.location.hash = decodeURIComponent($.param(state));
+
+    var stateHash = decodeURIComponent($.param(state));
+    pushState(`#${stateHash}`);
 
     scrollToResults(selector, 50);
   });

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -184,7 +184,7 @@ function bindPageChange(selector) {
     else delete state.page;
 
     var stateHash = decodeURIComponent($.param(state));
-    pushState(`#${stateHash}`);
+    pushState(state, `#${stateHash}`);
 
     scrollToResults(selector, 50);
   });

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -8,6 +8,7 @@ import './recipe-list.css'
 
 import { float2rat, getRecipe } from '../common';
 import { renderIngredient } from '../conversion';
+import { getState, pushState } from '../state';
 import { storage } from '../storage';
 import { addRecipe } from '../models/recipes';
 import { starRecipe, unstarRecipe } from '../models/starred';
@@ -178,14 +179,13 @@ function scrollToResults(selector, delay) {
 
 function bindPageChange(selector) {
   $(`${selector} table[data-row-attributes]`).on('page-change.bs.table', function(e, number, size) {
-    var state = history.state;
-
     // Write the new page number into the application's state
+    var state = getState();
     if (number > 1) state.page = number;
     else delete state.page;
 
     var stateHash = decodeURIComponent($.param(state));
-    window.history.pushState(state, '', `#${stateHash}`);
+    pushState(state, `#${stateHash}`);
 
     scrollToResults(selector, 50);
   });
@@ -236,7 +236,8 @@ function bindPostBody(selector) {
     $(this).parents('div.recipe-list').show();
 
     // If the user is on the page containing this table, scroll it into view
-    if (`#${history.state.action}` === selector) {
+    var state = getState();
+    if (`#${state.action}` === selector) {
       scrollToResults(selector);
     }
   });

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -148,7 +148,4 @@ $(function() {
   bindLoadEvent('#search', emptyResultHandler);
   bindLoadEvent('#search', refinementHandler);
   bindLoadEvent('#search', addSorting);
-
-  window.onhashchange = loadState;
-  loadState();
 });

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -30,7 +30,7 @@ function pushSearch() {
   if (window.location.hash === `#${stateHash}`) {
     $('#search table[data-row-attributes]').trigger('page-change.bs.table');
   }
-  pushState(`#${stateHash}`);
+  pushState(state, `#${stateHash}`);
 }
 $('#search form button').on('click', pushSearch);
 
@@ -126,7 +126,7 @@ function createSortPrompt() {
     delete state.page;
 
     var stateHash = decodeURIComponent($.param(state));
-    pushState(`#${stateHash}`);
+    pushState(state, `#${stateHash}`);
   });
 
   var sortPrompt = $('<span>').text('Order by ');

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -7,7 +7,7 @@ import './search.css';
 
 import '../autosuggest';
 import { localize } from '../i18n';
-import { getState, loadPage, loadState } from '../state';
+import { getState, loadPage, loadState, pushState } from '../state';
 import { initTable, bindLoadEvent } from '../ui/recipe-list';
 
 export { renderSearch, renderIndividual };
@@ -30,8 +30,7 @@ function pushSearch() {
   if (window.location.hash === `#${stateHash}`) {
     $('#search table[data-row-attributes]').trigger('page-change.bs.table');
   }
-
-  window.location.hash = stateHash;
+  pushState(`#${stateHash}`);
 }
 $('#search form button').on('click', pushSearch);
 
@@ -125,7 +124,9 @@ function createSortPrompt() {
     var state = getState();
     state.sort = this.value;
     delete state.page;
-    window.location.hash = decodeURIComponent($.param(state));
+
+    var stateHash = decodeURIComponent($.param(state));
+    pushState(`#${stateHash}`);
   });
 
   var sortPrompt = $('<span>').text('Order by ');

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -129,6 +129,7 @@ function createSortPrompt() {
 
     var stateHash = decodeURIComponent($.param(state));
     history.pushState(state, '', `#${stateHash}`);
+    $(window).trigger('popstate');
   });
 
   var sortPrompt = $('<span>').text('Order by ');

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -7,7 +7,6 @@ import './search.css';
 
 import '../autosuggest';
 import { localize } from '../i18n';
-import { loadPage } from '../state';
 import { initTable, bindLoadEvent } from '../ui/recipe-list';
 
 export { renderSearch, renderIndividual };
@@ -49,8 +48,6 @@ function renderSearch() {
     url: '/api/recipes/search?' + $.param(params),
     pageNumber: Number(state.page || 1)
   });
-
-  loadPage('search');
 }
 
 function renderIndividual() {

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -149,6 +149,6 @@ $(function() {
   bindLoadEvent('#search', refinementHandler);
   bindLoadEvent('#search', addSorting);
 
-  window.onpopstate = loadState;
+  window.onhashchange = loadState;
   loadState();
 });

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -7,7 +7,7 @@ import './search.css';
 
 import '../autosuggest';
 import { localize } from '../i18n';
-import { getState, loadPage, pushState } from '../state';
+import { loadPage } from '../state';
 import { initTable, bindLoadEvent } from '../ui/recipe-list';
 
 export { renderSearch, renderIndividual };
@@ -21,7 +21,7 @@ function pushSearch() {
       state[fragment] = data.join(',');
     }
   })
-  var sortChoice = getState().sort;
+  var sortChoice = window.history.state.sort;
   if (sortChoice) state['sort'] = sortChoice;
 
   // If the requested search is a repeat of the current state, perform a results refresh
@@ -30,7 +30,7 @@ function pushSearch() {
   if (window.location.hash === `#${stateHash}`) {
     $('#search table[data-row-attributes]').trigger('page-change.bs.table');
   }
-  pushState(state, `#${stateHash}`);
+  window.history.pushState(state, '', `#${stateHash}`);
   $(window).trigger('popstate');
 }
 $('#search form button').on('click', pushSearch);
@@ -42,7 +42,7 @@ function renderSearch() {
     equipment: $('#equipment').val(),
   };
 
-  var state = getState();
+  var state = window.history.state;
   if (state.sort) params['sort'] = state.sort;
 
   $('#search table[data-row-attributes]').bootstrapTable('refresh', {
@@ -54,7 +54,7 @@ function renderSearch() {
 }
 
 function renderIndividual() {
-  var id = getState().id;
+  var id = window.history.state.id;
   $('#search table[data-row-attributes]').bootstrapTable('refresh', {
     url: '/api/recipes/' + encodeURIComponent(id) + '/view'
   });
@@ -111,7 +111,7 @@ function createSortPrompt() {
     {val: 'relevance', text: 'most ingredients used'},
     {val: 'duration', text: 'shortest time to make'},
   ];
-  var sortChoice = getState().sort || sortOptions[0].val;
+  var sortChoice = window.history.state.sort || sortOptions[0].val;
 
   var sortSelect = $('<select>', {'class': 'sort'}).attr('aria-label', 'Recipe sort selection');
   $(sortOptions).each(function() {
@@ -122,12 +122,12 @@ function createSortPrompt() {
     sortSelect.append(sortOption);
   });
   sortSelect.on('change', function() {
-    var state = getState();
+    var state = window.history.state;
     state.sort = this.value;
     delete state.page;
 
     var stateHash = decodeURIComponent($.param(state));
-    pushState(state, `#${stateHash}`);
+    window.history.pushState(state, '', `#${stateHash}`);
   });
 
   var sortPrompt = $('<span>').text('Order by ');

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -13,6 +13,8 @@ export { renderSearch, renderIndividual };
 
 function pushSearch() {
   var state = {'action': 'search'};
+  if (history.state && history.state.sort) state['sort'] = history.state.sort;
+
   ['#include', '#exclude', '#equipment'].forEach(function (element) {
     var fragment = element.replace('#', '');
     var data = $(element).val();
@@ -20,8 +22,6 @@ function pushSearch() {
       state[fragment] = data.join(',');
     }
   })
-  var sortChoice = window.history.state.sort;
-  if (sortChoice) state['sort'] = sortChoice;
 
   // If the requested search is a repeat of the current state, perform a results refresh
   // This is done to ensure that the results are scrolled into view
@@ -41,7 +41,7 @@ function renderSearch() {
     equipment: $('#equipment').val(),
   };
 
-  var state = window.history.state;
+  var state = history.state || {};
   if (state.sort) params['sort'] = state.sort;
 
   $('#search table[data-row-attributes]').bootstrapTable('refresh', {
@@ -51,7 +51,7 @@ function renderSearch() {
 }
 
 function renderIndividual() {
-  var id = window.history.state.id;
+  var id = history.state.id;
   $('#search table[data-row-attributes]').bootstrapTable('refresh', {
     url: '/api/recipes/' + encodeURIComponent(id) + '/view'
   });
@@ -108,7 +108,9 @@ function createSortPrompt() {
     {val: 'relevance', text: 'most ingredients used'},
     {val: 'duration', text: 'shortest time to make'},
   ];
-  var sortChoice = window.history.state.sort || sortOptions[0].val;
+
+  var state = history.state || {};
+  var sortChoice = state.sort || sortOptions[0].val;
 
   var sortSelect = $('<select>', {'class': 'sort'}).attr('aria-label', 'Recipe sort selection');
   $(sortOptions).each(function() {
@@ -119,12 +121,14 @@ function createSortPrompt() {
     sortSelect.append(sortOption);
   });
   sortSelect.on('change', function() {
-    var state = window.history.state;
+    var state = history.state;
+
+    // Write the new sort selection, and reset to the first page
     state.sort = this.value;
     delete state.page;
 
     var stateHash = decodeURIComponent($.param(state));
-    window.history.pushState(state, '', `#${stateHash}`);
+    history.pushState(state, '', `#${stateHash}`);
   });
 
   var sortPrompt = $('<span>').text('Order by ');

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -31,6 +31,7 @@ function pushSearch() {
     $('#search table[data-row-attributes]').trigger('page-change.bs.table');
   }
   pushState(state, `#${stateHash}`);
+  $(window).trigger('popstate');
 }
 $('#search form button').on('click', pushSearch);
 

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -149,6 +149,6 @@ $(function() {
   bindLoadEvent('#search', refinementHandler);
   bindLoadEvent('#search', addSorting);
 
-  window.onhashchange = loadState;
+  window.onpopstate = loadState;
   loadState();
 });

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -7,7 +7,7 @@ import './search.css';
 
 import '../autosuggest';
 import { localize } from '../i18n';
-import { getState, loadPage, loadState, pushState } from '../state';
+import { getState, loadPage, pushState } from '../state';
 import { initTable, bindLoadEvent } from '../ui/recipe-list';
 
 export { renderSearch, renderIndividual };

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -7,14 +7,13 @@ import './search.css';
 
 import '../autosuggest';
 import { localize } from '../i18n';
+import { getState, pushState } from '../state';
 import { initTable, bindLoadEvent } from '../ui/recipe-list';
 
 export { renderSearch, renderIndividual };
 
 function pushSearch() {
   var state = {'action': 'search'};
-  if (history.state && history.state.sort) state['sort'] = history.state.sort;
-
   ['#include', '#exclude', '#equipment'].forEach(function (element) {
     var fragment = element.replace('#', '');
     var data = $(element).val();
@@ -22,6 +21,8 @@ function pushSearch() {
       state[fragment] = data.join(',');
     }
   })
+  var sortChoice = getState().sort;
+  if (sortChoice) state['sort'] = sortChoice;
 
   // If the requested search is a repeat of the current state, perform a results refresh
   // This is done to ensure that the results are scrolled into view
@@ -29,7 +30,7 @@ function pushSearch() {
   if (window.location.hash === `#${stateHash}`) {
     $('#search table[data-row-attributes]').trigger('page-change.bs.table');
   }
-  window.history.pushState(state, '', `#${stateHash}`);
+  pushState(state, `#${stateHash}`);
   $(window).trigger('popstate');
 }
 $('#search form button').on('click', pushSearch);
@@ -128,7 +129,7 @@ function createSortPrompt() {
     delete state.page;
 
     var stateHash = decodeURIComponent($.param(state));
-    history.pushState(state, '', `#${stateHash}`);
+    pushState(state, `#${stateHash}`);
     $(window).trigger('popstate');
   });
 

--- a/src/index.html
+++ b/src/index.html
@@ -41,7 +41,7 @@
       </ul>
       <ul class="navbar-nav ml-auto">
         <li class="nav-item">
-          <a class="nav-link float-left fa fa-info" data-toggle="modal" data-target="#about-modal"></a>
+          <a href="#about-application" class="nav-link float-left fa fa-info"></a>
         </li>
       </ul>
       </div>


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The application has been using `window.location.hash` in conjunction with anchor links to determine the user's current state, and the `onhashchange` window event to catch navigation events.

These have been working reasonably, but have a few disadvantages, particularly around browser page refresh behaviour (see #88).

In this set of changes, the application is migrated to use the browser [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) as standard.  This is currently at [97.13% fully-supported adoption](https://caniuse.com/#feat=history) and so it should be safe to include.

### Briefly summarize the changes
1. Write navigation state changes via `history.pushState`
1. Catch navigation events using `window.onpopstate`
1. Where necessary, trigger `popstate` events manually
1. Load state via `history.state`

### How have the changes been tested?
1. Local testing in a development instance of the application

**List any issues that this change relates to**
Resolves #88.