### PR TITLE
Fixup: restore call to select2.close

### DIFF
--- a/src/app/autosuggest.js
+++ b/src/app/autosuggest.js
@@ -63,6 +63,7 @@ $(function() {
       var suggestionsOpen = !selectElement.select2('isOpen');
       if (suggestionsOpen) return;
 
+      selectElement.select2('close');
       $('#search form button').trigger('click');
     }
   });


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The custom handler for `enter` keypresses inside [select2](https://github.com/select2/select2/) fields was recently updated and a call to `select2`'s `close` method was [accidentally removed](https://github.com/openculinary/frontend/pull/110/files#diff-2222c67f9494dce42fb3d3a4c2f98355L57).

Restoring this call ensures that `select2` correct unbinds the `mousedown` event handler when a dropdown item is selected.

### Briefly summarize the changes
1. Restore an accidentally-removed call to `select2`'s `close` function

### How have the changes been tested?
1. Local testing in a development instance of the application

**List any issues that this change relates to**
Fixes #117 
