### PR TITLE
Enable fallback from browser History API to hyperlink hash state

### DIFF
--- a/src/app/state.js
+++ b/src/app/state.js
@@ -9,7 +9,7 @@ function getState() {
   if (!history.state && location.hash) {
     var state = {}
     var urlParams = new URLSearchParams(window.location.hash.slice(1));
-    urlParams.forEach((value, key) => { state[key] = state[key] || value });
+    urlParams.forEach((value, key) => { state[key] = value });
     return state;
   }
   return history.state;

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -7,7 +7,7 @@ export { getState, pushState };
 function getState() {
   var state = history.state || {};
   var urlHash = window.location.hash || '#search';
-  var urlParams = new URLSearchParams(urlHash);
+  var urlParams = new URLSearchParams(urlHash.slice(1));
   urlParams.forEach(function(value, key) {
     state[key] = state[key] || value;
   });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -5,13 +5,14 @@ import { renderSearch, renderIndividual } from './views/search';
 export { getState, pushState };
 
 function getState() {
-  if (!history.state && window.location.hash) {
-    var state = {'search': null};
+  if (!history.state && !location.hash) return {'search': null};
+  if (!history.state && location.hash) {
+    var state = {}
     var urlParams = new URLSearchParams(window.location.hash.slice(1));
     urlParams.forEach((value, key) => { state[key] = state[key] || value });
-    pushState(state);
+    return state;
   }
-  return history.state || {};
+  return history.state;
 }
 
 function pushState(state, hash) {

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -5,13 +5,15 @@ import { renderSearch, renderIndividual } from './views/search';
 export { getState, pushState };
 
 function getState() {
-  var state = history.state || {};
-  var urlHash = window.location.hash || '#search';
-  var urlParams = new URLSearchParams(urlHash.slice(1));
-  urlParams.forEach(function(value, key) {
-    state[key] = state[key] || value;
-  });
-  return state;
+  if (!history.state && window.location.hash) {
+    var state = {'search': null};
+    var urlParams = new URLSearchParams(window.location.hash.slice(1));
+    urlParams.forEach(function(value, key) {
+      state[key] = state[key] || value;
+    });
+    pushState(state);
+  }
+  return history.state || {};
 }
 
 function pushState(state, hash) {

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -8,9 +8,7 @@ function getState() {
   if (!history.state && window.location.hash) {
     var state = {'search': null};
     var urlParams = new URLSearchParams(window.location.hash.slice(1));
-    urlParams.forEach(function(value, key) {
-      state[key] = state[key] || value;
-    });
+    urlParams.forEach((value, key) => { state[key] = state[key] || value });
     pushState(state);
   }
   return history.state || {};

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -5,7 +5,13 @@ import { renderSearch, renderIndividual } from './views/search';
 export { getState, pushState };
 
 function getState() {
-  return history.state || {};
+  var state = history.state || {};
+  var urlHash = window.location.hash || '#search';
+  var urlParams = new URLSearchParams(urlHash);
+  urlParams.forEach(function(value, key) {
+    state[key] = state[key] || value;
+  });
+  return state;
 }
 
 function pushState(state, hash) {
@@ -43,25 +49,21 @@ function loadAboutTab(tabId) {
 function loadState() {
   // If we encounter an empty state, display the homepage
   var state = getState();
-  var urlParams = new URLSearchParams(window.location.hash.slice(1));
-  if (Object.keys(state).length === 0 && urlParams.keys().next().done) {
-    urlParams.set('search', null);
-  }
 
   loadTags('#include', state.include);
   loadTags('#exclude', state.exclude);
   loadTags('#equipment', state.equipment);
 
   $('body > div.container[id]').each(function() {
-    if (urlParams.has(this.id)) loadPage(this.id);
+    if (this.id in state) loadPage(this.id);
   });
 
   $('#about-modal div.tab-pane[id]').each(function() {
-    if (urlParams.has(this.id)) loadAboutTab(this.id);
+    if (this.id in state) loadAboutTab(this.id);
   });
 
   var activeTab = $('.modal.show a.active').attr('href');
-  if (activeTab && !urlParams.has(activeTab.slice(1))) {
+  if (activeTab && !(activeTab.slice(1) in state)) {
     $('.modal.show').modal('hide');
     activeTab = null;
   }

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -42,7 +42,7 @@ function renderSearch() {
     equipment: $('#equipment').val(),
   };
 
-  var state = history.state || {};
+  var state = getState();
   if (state.sort) params['sort'] = state.sort;
 
   $('#search table[data-row-attributes]').bootstrapTable('refresh', {
@@ -52,7 +52,7 @@ function renderSearch() {
 }
 
 function renderIndividual() {
-  var id = history.state.id;
+  var id = getState().id;
   $('#search table[data-row-attributes]').bootstrapTable('refresh', {
     url: '/api/recipes/' + encodeURIComponent(id) + '/view'
   });
@@ -110,7 +110,7 @@ function createSortPrompt() {
     {val: 'duration', text: 'shortest time to make'},
   ];
 
-  var state = history.state || {};
+  var state = getState();
   var sortChoice = state.sort || sortOptions[0].val;
 
   var sortSelect = $('<select>', {'class': 'sort'}).attr('aria-label', 'Recipe sort selection');
@@ -122,7 +122,7 @@ function createSortPrompt() {
     sortSelect.append(sortOption);
   });
   sortSelect.on('change', function() {
-    var state = history.state;
+    var state = getState();
 
     // Write the new sort selection, and reset to the first page
     state.sort = this.value;


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
When a user loads a hyperlink to the application, the user agent is unlikely to have any existing navigation state.

In these cases we need to ensure that any state provided in the hyperlink is available in the initial state.

### Briefly summarize the changes
1. Populate state from user agent location.hash as a fallback from the History API
1. Fix an issue where `history.state` was being accessed directly instead of via the `getState` wrapper

### How have the changes been tested?
1. Local testing via a development instance of the application

**List any issues that this change relates to**
Fixes #120.