### PR TITLE
Search Results: render ingredient RecipeML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1709,6 +1709,11 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-flat-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
+      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw=="
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1238,11 +1238,6 @@
         }
       }
     },
-    "@ungap/global-this": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.3.1.tgz",
-      "integrity": "sha512-6gxLxSsXmt3XcC2p0mRjeHOtZemfs/IswAyWJZU0b8UvCQAegRpjSrQK0Y+u3OQQ3V0ZYQkHVCV9V3dxnlJ5Zw=="
-    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -1708,11 +1703,6 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
-    },
-    "array-flat-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
-      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw=="
     },
     "array-union": {
       "version": "1.0.2",
@@ -12237,23 +12227,12 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "xmldom-ts": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/xmldom-ts/-/xmldom-ts-0.3.1.tgz",
-      "integrity": "sha512-dmEBAK3Msm+BPVZOiwhXCyM0/q3BeiI4eoAPj2Us1nDhsPPhePtZ5RkgEdngNQQFp3j6QFKMLHlBIRUxdpomcQ=="
-    },
-    "xpath-ts": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/xpath-ts/-/xpath-ts-1.3.13.tgz",
-      "integrity": "sha512-eNVXzDWbCV9KEB6fGNQ3qHFGC9PWBH7y2h13vZ+CMPNqOTZ+fgYTG4Sb0p5bVHiAwZrzgE6/tx987003P3dYpA=="
-    },
-    "xslt-ts": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/xslt-ts/-/xslt-ts-1.1.8.tgz",
-      "integrity": "sha512-CO0QABM09xJylkZ2F9tV58Qvm0yap5K6ALG1jczlHah9pT+qVLNjG1jkGmVkn/wVYffss7sRkqbfj8GvtOz7Ag==",
+    "xslt-processor": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/xslt-processor/-/xslt-processor-0.11.5.tgz",
+      "integrity": "sha512-1sqWl7cfLLPpGi5cieiIlqqpQU3f44N7gfFzCqvi0Om53vxmwZIp877x5+H6HoxaL8cr1xGG3OWRR2FtOC7zTg==",
       "requires": {
-        "he": "^1.2.0",
-        "xpath-ts": "^1.3.13"
+        "he": "^1.2.0"
       },
       "dependencies": {
         "he": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1238,6 +1238,11 @@
         }
       }
     },
+    "@ungap/global-this": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.3.1.tgz",
+      "integrity": "sha512-6gxLxSsXmt3XcC2p0mRjeHOtZemfs/IswAyWJZU0b8UvCQAegRpjSrQK0Y+u3OQQ3V0ZYQkHVCV9V3dxnlJ5Zw=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -12226,6 +12231,11 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xmldom-ts": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/xmldom-ts/-/xmldom-ts-0.3.1.tgz",
+      "integrity": "sha512-dmEBAK3Msm+BPVZOiwhXCyM0/q3BeiI4eoAPj2Us1nDhsPPhePtZ5RkgEdngNQQFp3j6QFKMLHlBIRUxdpomcQ=="
     },
     "xpath-ts": {
       "version": "1.3.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12227,6 +12227,27 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "xpath-ts": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/xpath-ts/-/xpath-ts-1.3.13.tgz",
+      "integrity": "sha512-eNVXzDWbCV9KEB6fGNQ3qHFGC9PWBH7y2h13vZ+CMPNqOTZ+fgYTG4Sb0p5bVHiAwZrzgE6/tx987003P3dYpA=="
+    },
+    "xslt-ts": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/xslt-ts/-/xslt-ts-1.1.8.tgz",
+      "integrity": "sha512-CO0QABM09xJylkZ2F9tV58Qvm0yap5K6ALG1jczlHah9pT+qVLNjG1jkGmVkn/wVYffss7sRkqbfj8GvtOz7Ag==",
+      "requires": {
+        "he": "^1.2.0",
+        "xpath-ts": "^1.3.13"
+      },
+      "dependencies": {
+        "he": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+          "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+        }
+      }
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,6 @@
   "description": "frontend",
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",
-    "@ungap/global-this": "^0.3.1",
-    "array-flat-polyfill": "^1.0.1",
     "bootstrap": "^4.4.1",
     "bootstrap-table": "^1.16.0",
     "convert-units": "^2.3.4",
@@ -22,8 +20,7 @@
     "select2": "^4.0.13",
     "sortablejs": "^1.10.2",
     "tablesaw": "^3.1.2",
-    "xmldom-ts": "^0.3.1",
-    "xslt-ts": "^1.1.8"
+    "xslt-processor": "^0.11.5"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "popper.js": "^1.16.1",
     "select2": "^4.0.13",
     "sortablejs": "^1.10.2",
-    "tablesaw": "^3.1.2"
+    "tablesaw": "^3.1.2",
+    "xslt-ts": "^1.1.8"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@ungap/global-this": "^0.3.1",
+    "array-flat-polyfill": "^1.0.1",
     "bootstrap": "^4.4.1",
     "bootstrap-table": "^1.16.0",
     "convert-units": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "frontend",
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",
+    "@ungap/global-this": "^0.3.1",
     "bootstrap": "^4.4.1",
     "bootstrap-table": "^1.16.0",
     "convert-units": "^2.3.4",
@@ -20,6 +21,7 @@
     "select2": "^4.0.13",
     "sortablejs": "^1.10.2",
     "tablesaw": "^3.1.2",
+    "xmldom-ts": "^0.3.1",
     "xslt-ts": "^1.1.8"
   },
   "devDependencies": {

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -4,6 +4,11 @@ import { float2rat } from './common';
 
 export { renderQuantity };
 
+const decimalMeasures = [
+    'l',
+    'kg',
+];
+
 const expandMeasures = [
     'Tbs',
     'tsp',
@@ -41,7 +46,7 @@ function renderMagnitude(units, magnitude) {
     magnitude = Number(magnitude.toPrecision(3));
     return magnitude.toFixed();
   }
-  if (units && expandMeasures.indexOf(units) == -1) {
+  if (units && decimalMeasures.indexOf(units) >= 0) {
     return magnitude.toFixed(2) / 1;
   }
   var result = float2rat(magnitude);

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -2,7 +2,7 @@ import * as convert from 'convert-units';
 
 import { float2rat } from './common';
 
-export { renderQuantity, renderIngredient };
+export { renderQuantity };
 
 const expandMeasures = [
     'Tbs',
@@ -56,10 +56,6 @@ function renderMagnitude(units, magnitude) {
   return result;
 }
 
-function renderProduct(product) {
-  return `<span class="tag badge ${product.state}">${product.product}</span>`;
-}
-
 function renderUnits(units, magnitude) {
   var description = convert().describe(units);
   if (expandMeasures.indexOf(units) == -1) {
@@ -98,13 +94,4 @@ function renderQuantity(quantity) {
     'magnitude': renderedMagnitude,
     'units': renderedUnits
   };
-}
-
-function renderIngredient(ingredient) {
-  var renderedQuantity = renderQuantity(ingredient.quantity);
-  var renderedProduct = renderProduct(ingredient.product);
-  return {
-    'quantity': renderedQuantity,
-    'product': renderedProduct
-  }
 }

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -1,7 +1,4 @@
-import 'array-flat-polyfill';
-import '@ungap/global-this';
-import { DOMImplementationImpl, DOMParserImpl, XMLSerializerImpl } from 'xmldom-ts';
-import { install, xsltProcess } from 'xslt-ts';
+import { xsltProcess, xmlParse } from 'xslt-processor'
 
 export { renderToHTML };
 
@@ -30,14 +27,8 @@ const template = `
 
 
 function renderToHTML(doc) {
-    const parser = new DOMParserImpl();
-    const serializer = new XMLSerializerImpl();
-    const dom = new DOMImplementationImpl();
-
-    install(parser, serializer, dom);
-
-    const recipeML = parser.parseFromString(doc, 'text/xml');
-    const recipeXSLT = parser.parseFromString(template, 'text/xml');
+    const recipeML = xmlParse(doc);
+    const recipeXSLT = xmlParse(template);
 
     return xsltProcess(recipeML, recipeXSLT);
 }

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -32,9 +32,9 @@ const template = `
 <xsl:template match="ingredient">
 <div class="product">
 <xsl:apply-templates select="preceding-sibling::text()" />
-<div>
+<span class="tag badge required">
   <xsl:apply-templates select="node()" />
-</div>
+</span>
 <xsl:apply-templates select="following-sibling::text()" />
 </div>
 </xsl:template>

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -1,5 +1,26 @@
+import '@ungap/global-this';
+import { DOMImplementationImpl, DOMParserImpl, XMLSerializerImpl } from 'xmldom-ts';
+import { install, xsltProcess } from 'xslt-ts';
+
 export { renderToHTML };
 
-function renderToHTML(recipeML) {
-    return '<div />';
+const template = `
+<?xml version="1.0" encoding="utf-8" ?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:template match="/"><div /></xsl:template>
+</xsl:stylesheet>
+`;
+
+
+function renderToHTML(doc) {
+    const parser = new DOMParserImpl();
+    const serializer = new XMLSerializerImpl();
+    const dom = new DOMImplementationImpl();
+
+    install(parser, serializer, dom);
+
+    const recipeML = parser.parseFromString(doc, 'text/xml');
+    const recipeXSLT = parser.parseFromString(template, 'text/xml');
+
+    return xsltProcess(recipeML, recipeXSLT);
 }

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -55,6 +55,6 @@ function renderToHTML(doc) {
     });
     const quantityText = `${quantity.magnitude || ''} ${quantity.units || ''}`.trim();
 
-    recipeHTML.filter('div.quantity').text(quantityText);
+    recipeHTML.filter('div.quantity').html(quantityText);
     return recipeHTML.get().map(node => node.outerHTML).join('');
 }

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -30,9 +30,9 @@ const template = `
 </xsl:template>
 
 <xsl:template match="ingredient">
-<div>
-<xsl:apply-templates select="preceding-sibling::text()" />
 <div class="product">
+<xsl:apply-templates select="preceding-sibling::text()" />
+<div>
   <xsl:apply-templates select="node()" />
 </div>
 <xsl:apply-templates select="following-sibling::text()" />

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -30,11 +30,13 @@ const template = `
 </xsl:template>
 
 <xsl:template match="ingredient">
+<div>
 <xsl:apply-templates select="preceding-sibling::text()" />
 <div class="product">
   <xsl:apply-templates select="node()" />
 </div>
 <xsl:apply-templates select="following-sibling::text()" />
+</div>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -1,3 +1,4 @@
+import 'array-flat-polyfill';
 import '@ungap/global-this';
 import { DOMImplementationImpl, DOMParserImpl, XMLSerializerImpl } from 'xmldom-ts';
 import { install, xsltProcess } from 'xslt-ts';
@@ -7,7 +8,23 @@ export { renderToHTML };
 const template = `
 <?xml version="1.0" encoding="utf-8" ?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-<xsl:template match="/"><div /></xsl:template>
+
+<xsl:template match="/">
+  <xsl:apply-templates />
+</xsl:template>
+
+<xsl:template match="amt">
+<div class="quantity">
+  <xsl:value-of select="qty/text()" />
+  <xsl:text> </xsl:text>
+  <xsl:value-of select="unit/text()" />
+</div>
+</xsl:template>
+
+<xsl:template match="ingredient">
+<div class="product"><xsl:value-of select="text()" /></div>
+</xsl:template>
+
 </xsl:stylesheet>
 `;
 

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -1,0 +1,5 @@
+export { renderToHTML };
+
+function renderToHTML(recipeML) {
+    return '<div />';
+}

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -9,8 +9,10 @@ const template = `
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:template match="/">
-  <xsl:apply-templates select="//amt" />
-  <xsl:apply-templates select="//ingredient" />
+  <xml>
+    <xsl:apply-templates select="//amt" />
+    <xsl:apply-templates select="//ingredient" />
+  </xml>
 </xsl:template>
 
 <xsl:template match="text()">
@@ -49,12 +51,16 @@ function renderToHTML(doc) {
     const recipeXSLT = $.parseXML(template);
     var recipeHTML = $(xsltProcess(recipeML, recipeXSLT));
 
+    if (!recipeHTML.find('div.quantity').length) {
+      recipeHTML.prepend($('<div>', {'class': 'quantity'}));
+    }
+
     const quantity = renderQuantity({
-        magnitude: Number($(recipeML).find('qty').text()),
-        units: $(recipeML).find('unit').text(),
+      magnitude: Number($(recipeML).find('qty').text()),
+      units: $(recipeML).find('unit').text(),
     });
     const quantityText = `${quantity.magnitude || ''} ${quantity.units || ''}`.trim();
+    recipeHTML.find('div.quantity').html(quantityText);
 
-    recipeHTML.filter('div.quantity').html(quantityText);
-    return recipeHTML.get().map(node => node.outerHTML).join('');
+    return recipeHTML.children().get().map(node => node.outerHTML).join('');
 }

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -35,7 +35,7 @@ const template = `
 <xsl:template match="ingredient">
 <div class="product">
 <xsl:apply-templates select="preceding-sibling::text()" />
-<span class="tag badge required">
+<span class="tag badge">
   <xsl:apply-templates select="node()" />
 </span>
 <xsl:apply-templates select="following-sibling::text()" />
@@ -46,10 +46,12 @@ const template = `
 `.trim();
 
 
-function renderToHTML(doc) {
+function renderToHTML(doc, state) {
     const recipeML = $.parseXML(`<xml>${doc}</xml>`);
     const recipeXSLT = $.parseXML(template);
     var recipeHTML = $(xsltProcess(recipeML, recipeXSLT));
+
+    recipeHTML.find('div.product span.tag').addClass(state);
 
     if (!recipeHTML.find('div.quantity').length) {
       recipeHTML.prepend($('<div>', {'class': 'quantity'}));

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -1,5 +1,7 @@
 import { xsltProcess } from 'xslt-processor'
 
+import { renderQuantity } from './conversion';
+
 export { renderToHTML };
 
 const template = `
@@ -20,7 +22,6 @@ const template = `
 <xsl:template match="amt">
 <div class="quantity">
   <xsl:apply-templates select="qty" />
-  <xsl:if test="qty and unit"><xsl:text> </xsl:text></xsl:if>
   <xsl:apply-templates select="unit" />
 </div>
 </xsl:template>
@@ -46,6 +47,14 @@ const template = `
 function renderToHTML(doc) {
     const recipeML = $.parseXML(`<xml>${doc}</xml>`);
     const recipeXSLT = $.parseXML(template);
+    var recipeHTML = $(xsltProcess(recipeML, recipeXSLT));
 
-    return xsltProcess(recipeML, recipeXSLT);
+    const quantity = renderQuantity({
+        magnitude: Number($(recipeML).find('qty').text()),
+        units: $(recipeML).find('unit').text(),
+    });
+    const quantityText = `${quantity.magnitude || ''} ${quantity.units || ''}`.trim();
+
+    recipeHTML.filter('div.quantity').text(quantityText);
+    return recipeHTML.get().map(node => node.outerHTML).join('');
 }

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -1,4 +1,4 @@
-import { xsltProcess, xmlParse } from 'xslt-processor'
+import { xsltProcess } from 'xslt-processor'
 
 export { renderToHTML };
 
@@ -40,12 +40,12 @@ const template = `
 </xsl:template>
 
 </xsl:stylesheet>
-`;
+`.trim();
 
 
 function renderToHTML(doc) {
-    const recipeML = xmlParse(`<xml>${doc}</xml>`);
-    const recipeXSLT = xmlParse(template);
+    const recipeML = $.parseXML(`<xml>${doc}</xml>`);
+    const recipeXSLT = $.parseXML(template);
 
     return xsltProcess(recipeML, recipeXSLT);
 }

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -7,19 +7,34 @@ const template = `
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:template match="/">
-  <xsl:apply-templates />
+  <xsl:apply-templates select="//amt" />
+  <xsl:apply-templates select="//ingredient" />
+</xsl:template>
+
+<xsl:template match="text()">
+  <xsl:if test="not(. = 'undefined')">
+  <xsl:value-of select="." />
+  </xsl:if>
 </xsl:template>
 
 <xsl:template match="amt">
 <div class="quantity">
-  <xsl:value-of select="qty/text()" />
-  <xsl:text> </xsl:text>
-  <xsl:value-of select="unit/text()" />
+  <xsl:apply-templates select="qty" />
+  <xsl:if test="qty and unit"><xsl:text> </xsl:text></xsl:if>
+  <xsl:apply-templates select="unit" />
 </div>
 </xsl:template>
 
+<xsl:template match="qty|unit">
+  <xsl:apply-templates select="node()" />
+</xsl:template>
+
 <xsl:template match="ingredient">
-<div class="product"><xsl:value-of select="text()" /></div>
+<xsl:apply-templates select="preceding-sibling::text()" />
+<div class="product">
+  <xsl:apply-templates select="node()" />
+</div>
+<xsl:apply-templates select="following-sibling::text()" />
 </xsl:template>
 
 </xsl:stylesheet>
@@ -27,7 +42,7 @@ const template = `
 
 
 function renderToHTML(doc) {
-    const recipeML = xmlParse(doc);
+    const recipeML = xmlParse(`<xml>${doc}</xml>`);
     const recipeXSLT = xmlParse(template);
 
     return xsltProcess(recipeML, recipeXSLT);

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -100,7 +100,7 @@ function contentFormatter(recipe) {
   var ingredients = $('<div />', {'class': 'tab ingredients'});
   var ingredientList = $('<div  />');
   $.each(recipe.ingredients, function() {
-    ingredientList.append(renderToHTML(this.markup));
+    ingredientList.append(renderToHTML(this.markup, this.state));
     ingredientList.append($('<div  />', {'style': 'clear: both'}));
   });
   ingredients.append(ingredientList);

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -6,7 +6,7 @@ import 'tablesaw/dist/stackonly/tablesaw.stackonly.css';
 import './recipe-list.css'
 
 import { float2rat, getRecipe } from '../common';
-import { renderIngredient } from '../conversion';
+import { renderToHTML } from '../recipeml';
 import { getState, pushState } from '../state';
 import { storage } from '../storage';
 import { addRecipe } from '../models/recipes';
@@ -23,31 +23,6 @@ export {
 
 function renderTokens(tokens) {
   return tokens.map(renderToken).join('');
-}
-
-function renderIngredients(tokens) {
-  var collectedTokens = {};
-  tokens.map(token => {
-    collectedTokens[token.type] = token.value;
-    if (token.type === 'product') collectedTokens.product = {
-      product: token.value,
-      state: token.state,
-    };
-  });
-  if (collectedTokens.product && collectedTokens.units) {
-    var ingredient = renderIngredient({
-      product: collectedTokens.product,
-      quantity: {
-        magnitude: collectedTokens.quantity,
-        units: collectedTokens.units
-      }
-    });
-    return `<div class="quantity">${ingredient.quantity.magnitude || ''} ${ingredient.quantity.units || ''}</div><div class="product">${ingredient.product}</div>`.trim();
-  }
-
-  var quantity = renderTokens(tokens.filter(token => token.type != 'product'));
-  var product = renderTokens(tokens.filter(token => token.type == 'product'));
-  return `<div class="quantity">${quantity}</div><div class="product">${product}</div>`;
 }
 
 function renderToken(token) {
@@ -125,7 +100,7 @@ function contentFormatter(recipe) {
   var ingredients = $('<div />', {'class': 'tab ingredients'});
   var ingredientList = $('<div  />');
   $.each(recipe.ingredients, function() {
-    ingredientList.append(renderIngredients(this.tokens));
+    ingredientList.append(renderToHTML(this.markup));
     ingredientList.append($('<div  />', {'style': 'clear: both'}));
   });
   ingredients.append(ingredientList);

--- a/static/vendors/RecipeML/LICENSE
+++ b/static/vendors/RecipeML/LICENSE
@@ -1,0 +1,35 @@
+RecipeML Public License Version 1.0
+
+Copyright (c) FormatData. All rights reserved.
+Definitions
+
+"RecipeML Data" refers to a unit of data with RecipeML markup that is meant to comply with the RecipeML specification as posted on the FormatData site.
+
+"RecipeML Processing Software" refers to software written by a third party that reads, creates, edits, stores or otherwise processes RecipeML data according to the rules set forth in the RecipeML specification and DTD ("RecipeML format"). Generic XML processors are exempt from this definition.
+Requirements
+
+Distribution of RecipeML Processing Software in source and/or binary forms is permitted provided that the following conditions are met:
+
+1. Distributions in source code must retain the above copyright notice and this list of conditions.
+
+2. Distributions in binary form must reproduce the above copyright notice and this list of conditions in the documentation and/or other materials provided with the distribution.
+
+3. All advertising materials and documentation for RecipeML Processing Software must display the following acknowledgment:
+
+   "This product is RecipeML compatible."
+
+4. Names associated with RecipeML or FormatData must not be used to endorse or promote RecipeML Processing Software without prior written permission from FormatData. For written permission, please contact RecipeML@formatdata.com.
+
+(Re)distribution of machine-readable representations of the RecipeML format are permitted provided that the following conditions are met:
+
+1. Distributions of any DTDs, XML-Schema or any other schema-representation documents produced by FormatData must retain the copyright notice in the header intact.
+
+2. The name "RecipeML" can only be applied if a modified schema representation (DTD, XML-Schema document, etc. as edited or produced by a third party) exactly represents the RecipeML format set forth in the RecipeML specification, i.e., the same set of documents will validate against the third party representation as the representation (DTD, etc.) of any version of the RecipeML format posted on the FormatData site; past, present or future.
+
+3. The formal namespace and public identifier set forth in the RecipeML specification can only be applied to a modified schema representation if that schema representation exactly represents the RecipeML format according to the criteria in (2).
+
+Disclaimer
+
+THIS SOFTWARE IS PROVIDED BY FORMATDATA "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FORMATDATA OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+© 2000 FormatData

--- a/test/recipeml.js
+++ b/test/recipeml.js
@@ -9,8 +9,8 @@ function recipeMLHelper(ingredient, product_id, quantity, units, preamble, posta
 describe('html rendering', function() {
 
   it('renders simple product', function() {
-    var recipeML = '<amt><qty>half</qty><unit>bag</unit></amt><ingredient>potato wedges</ingredient>';
-    var expected = '<div class="quantity">half bag</div><div class="product"><span class="tag badge required">potato wedges</span></div>';
+    var recipeML = '<amt><qty>0.5</qty><unit>bag</unit></amt><ingredient>potato wedges</ingredient>';
+    var expected = '<div class="quantity">0.5 bag</div><div class="product"><span class="tag badge required">potato wedges</span></div>';
 
     var rendered = renderToHTML(recipeML);
 
@@ -29,6 +29,15 @@ describe('html rendering', function() {
   it('renders without units', function() {
     var recipeML = '<amt><qty>1</qty></amt><ingredient>onion</ingredient>';
     var expected = '<div class="quantity">1</div><div class="product"><span class="tag badge required">onion</span></div>';
+
+    var rendered = renderToHTML(recipeML);
+
+    assert.equal(expected, rendered);
+  });
+
+  it('renders human quantities', function() {
+    var recipeML = '<amt><qty>14.79</qty><unit>ml</unit></amt><ingredient>olive oil</ingredient>';
+    var expected = '<div class="quantity">3 teaspoons</div><div class="product"><span class="tag badge required">olive oil</span></div>';
 
     var rendered = renderToHTML(recipeML);
 

--- a/test/recipeml.js
+++ b/test/recipeml.js
@@ -2,19 +2,33 @@ import * as assert from 'assert';
 
 import { renderToHTML } from '../src/app/recipeml';
 
-function recipeMLHelper(ingredient, product_id, quantity, units) {
-    return `<amt><qty>${quantity}</qty><unit>${units}</unit></amt><ingredient href="products/${product_id}">${ingredient}</ingredient>`;
-}
-
-function expectedProductHTML(product, quantity, units) {
-  return `<div class="quantity">${quantity} ${units}</div><div class="product">${product}</div>`;
+function recipeMLHelper(ingredient, product_id, quantity, units, preamble, postamble) {
+    return `<amt><qty>${quantity}</qty><unit>${units}</unit></amt>${preamble}<ingredient href="products/${product_id}">${ingredient}</ingredient>${postamble}`;
 }
 
 describe('html rendering', function() {
 
   it('renders simple product', function() {
-    var recipeML = recipeMLHelper('potato wedges', 'potato_wedg', 'half', 'bag');
-    var expected = expectedProductHTML('potato wedges', 'half', 'bag');
+    var recipeML = '<amt><qty>half</qty><unit>bag</unit></amt><ingredient>potato wedges</ingredient>';
+    var expected = '<div class="quantity">half bag</div><div class="product">potato wedges</div>';
+
+    var rendered = renderToHTML(recipeML);
+
+    assert.equal(expected, rendered);
+  });
+
+  it('renders contextual product', function() {
+    var recipeML = '<amt><qty>1</qty><unit>whole</unit></amt>small <ingredient>onion</ingredient> diced';
+    var expected = '<div class="quantity">1 whole</div>small <div class="product">onion</div> diced';
+
+    var rendered = renderToHTML(recipeML);
+
+    assert.equal(expected, rendered);
+  });
+
+  it('renders without units', function() {
+    var recipeML = '<amt><qty>1</qty></amt><ingredient>onion</ingredient>';
+    var expected = '<div class="quantity">1</div><div class="product">onion</div>';
 
     var rendered = renderToHTML(recipeML);
 

--- a/test/recipeml.js
+++ b/test/recipeml.js
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import { renderToHTML } from '../src/app/recipeml';
 
 function recipeMLHelper(ingredient, product_id, quantity, units) {
-    return `<amt><qty>${quantity}</qty><unit>${units}</unit></amt><ingredient href="products/${product_id}">${ingredient}</ingredient>`; 
+    return `<amt><qty>${quantity}</qty><unit>${units}</unit></amt><ingredient href="products/${product_id}">${ingredient}</ingredient>`;
 }
 
 function expectedProductHTML(product, quantity, units) {

--- a/test/recipeml.js
+++ b/test/recipeml.js
@@ -1,0 +1,24 @@
+import * as assert from 'assert';
+
+import { renderToHTML } from '../src/app/recipeml';
+
+function recipeMLHelper(ingredient, product_id, quantity, units) {
+    return `<amt><qty>${quantity}</qty><unit>${units}</unit></amt><ingredient href="products/${product_id}">${ingredient}</ingredient>`; 
+}
+
+function expectedProductHTML(product, quantity, units) {
+  return `<div class="quantity">${quantity} ${units}</div><div class="product">${product}</div>`;
+}
+
+describe('html rendering', function() {
+
+  it('renders simple product', function() {
+    var recipeML = recipeMLHelper('potato wedges', 'potato_wedg', 'half', 'bag');
+    var expected = expectedProductHTML('potato wedges', 'half', 'bag');
+
+    var rendered = renderToHTML(recipeML);
+
+    assert.equal(expected, rendered);
+  });
+
+});

--- a/test/recipeml.js
+++ b/test/recipeml.js
@@ -10,7 +10,7 @@ describe('html rendering', function() {
 
   it('renders simple product', function() {
     var recipeML = '<amt><qty>half</qty><unit>bag</unit></amt><ingredient>potato wedges</ingredient>';
-    var expected = '<div class="quantity">half bag</div><div class="product">potato wedges</div>';
+    var expected = '<div class="quantity">half bag</div><div class="product"><span class="tag badge required">potato wedges</span></div>';
 
     var rendered = renderToHTML(recipeML);
 
@@ -19,7 +19,7 @@ describe('html rendering', function() {
 
   it('renders contextual product', function() {
     var recipeML = '<amt><qty>1</qty><unit>whole</unit></amt>small <ingredient>onion</ingredient> diced';
-    var expected = '<div class="quantity">1 whole</div>small <div class="product">onion</div> diced';
+    var expected = '<div class="quantity">1 whole</div><div class="product">small <span class="tag badge required">onion</span> diced</div>';
 
     var rendered = renderToHTML(recipeML);
 
@@ -28,7 +28,7 @@ describe('html rendering', function() {
 
   it('renders without units', function() {
     var recipeML = '<amt><qty>1</qty></amt><ingredient>onion</ingredient>';
-    var expected = '<div class="quantity">1</div><div class="product">onion</div>';
+    var expected = '<div class="quantity">1</div><div class="product"><span class="tag badge required">onion</span></div>';
 
     var rendered = renderToHTML(recipeML);
 

--- a/test/recipeml.js
+++ b/test/recipeml.js
@@ -10,7 +10,7 @@ describe('html rendering', function() {
 
   it('renders simple product', function() {
     var recipeML = '<amt><qty>0.5</qty><unit>bag</unit></amt><ingredient>potato wedges</ingredient>';
-    var expected = '<div class="quantity"><sup>1</sup>⁄<sub>2</sub> bag</div><div class="product"><span class="tag badge required">potato wedges</span></div>';
+    var expected = '<div class="quantity"><sup>1</sup>⁄<sub>2</sub> bag</div><div class="product"><span class="tag badge">potato wedges</span></div>';
 
     var rendered = renderToHTML(recipeML);
 
@@ -19,7 +19,7 @@ describe('html rendering', function() {
 
   it('renders contextual product', function() {
     var recipeML = '<amt><qty>1</qty><unit>whole</unit></amt>small <ingredient>onion</ingredient> diced';
-    var expected = '<div class="quantity">1 whole</div><div class="product">small <span class="tag badge required">onion</span> diced</div>';
+    var expected = '<div class="quantity">1 whole</div><div class="product">small <span class="tag badge">onion</span> diced</div>';
 
     var rendered = renderToHTML(recipeML);
 
@@ -28,7 +28,7 @@ describe('html rendering', function() {
 
   it('renders without units', function() {
     var recipeML = '<amt><qty>1</qty></amt><ingredient>onion</ingredient>';
-    var expected = '<div class="quantity">1</div><div class="product"><span class="tag badge required">onion</span></div>';
+    var expected = '<div class="quantity">1</div><div class="product"><span class="tag badge">onion</span></div>';
 
     var rendered = renderToHTML(recipeML);
 
@@ -37,7 +37,7 @@ describe('html rendering', function() {
 
   it('renders human quantities', function() {
     var recipeML = '<amt><qty>14.79</qty><unit>ml</unit></amt><ingredient>olive oil</ingredient>';
-    var expected = '<div class="quantity">3 teaspoons</div><div class="product"><span class="tag badge required">olive oil</span></div>';
+    var expected = '<div class="quantity">3 teaspoons</div><div class="product"><span class="tag badge">olive oil</span></div>';
 
     var rendered = renderToHTML(recipeML);
 
@@ -46,9 +46,18 @@ describe('html rendering', function() {
 
   it('always renders a quantity element', function() {
     var recipeML = '<ingredient>bananas</ingredient>';
-    var expected = '<div class="quantity"></div><div class="product"><span class="tag badge required">bananas</span></div>';
+    var expected = '<div class="quantity"></div><div class="product"><span class="tag badge">bananas</span></div>';
 
     var rendered = renderToHTML(recipeML);
+
+    assert.equal(expected, rendered);
+  });
+
+  it('renders ingredient state', function() {
+    var recipeML = '<ingredient>garlic</ingredient>';
+    var expected = '<div class="quantity"></div><div class="product"><span class="tag badge available">garlic</span></div>';
+
+    var rendered = renderToHTML(recipeML, 'available');
 
     assert.equal(expected, rendered);
   });

--- a/test/recipeml.js
+++ b/test/recipeml.js
@@ -10,7 +10,7 @@ describe('html rendering', function() {
 
   it('renders simple product', function() {
     var recipeML = '<amt><qty>0.5</qty><unit>bag</unit></amt><ingredient>potato wedges</ingredient>';
-    var expected = '<div class="quantity">0.5 bag</div><div class="product"><span class="tag badge required">potato wedges</span></div>';
+    var expected = '<div class="quantity"><sup>1</sup>⁄<sub>2</sub> bag</div><div class="product"><span class="tag badge required">potato wedges</span></div>';
 
     var rendered = renderToHTML(recipeML);
 

--- a/test/recipeml.js
+++ b/test/recipeml.js
@@ -44,4 +44,13 @@ describe('html rendering', function() {
     assert.equal(expected, rendered);
   });
 
+  it('always renders a quantity element', function() {
+    var recipeML = '<ingredient>bananas</ingredient>';
+    var expected = '<div class="quantity"></div><div class="product"><span class="tag badge required">bananas</span></div>';
+
+    var rendered = renderToHTML(recipeML);
+
+    assert.equal(expected, rendered);
+  });
+
 });


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Since https://github.com/openculinary/api/pull/49, the RecipeRadar [`api`](https://github.com/openculinary/api/) service includes [RecipeML](http://www.formatdata.com/recipeml/spec/recipeml-spec.html) markup alongside each recipe ingredient.

This change enables rendering of RecipeML in the frontend application, by using an XSLT stylesheet to render the markup into HTML.

![image](https://user-images.githubusercontent.com/55152140/80280700-9aca0480-86fd-11ea-8f0b-b9aaf3fc2615.png)

Image: [Tofu Keema](https://www.allrecipes.com/recipe/43805/tofu-keema/) appearing in search results with ingredients rendered via RecipeML

### Briefly summarize the changes
1. Perform XSLT transformation from RecipeML in API responses into HTML for the user-agent

### How have the changes been tested?
1. Unit test coverage is provided
1. Local testing and inspection via a development instance of the application

**List any issues that this change relates to**
Fixes #103 
