### PR TITLE
Search Results: render direction RecipeML

### DIFF
--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -2,7 +2,7 @@ import { xsltProcess } from 'xslt-processor'
 
 import { renderQuantity } from './conversion';
 
-export { renderToHTML, renderDirectionHTML };
+export { renderIngredientHTML, renderDirectionHTML };
 
 const template = `
 <?xml version="1.0" encoding="utf-8" ?>
@@ -46,7 +46,7 @@ const template = `
 `.trim();
 
 
-function renderToHTML(doc, state) {
+function renderIngredientHTML(doc, state) {
     const recipeML = $.parseXML(`<xml>${doc}</xml>`);
     const recipeXSLT = $.parseXML(template);
     var recipeHTML = $(xsltProcess(recipeML, recipeXSLT));

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -71,8 +71,8 @@ function renderDirectionHTML(doc) {
     const xml = $.parseXML(`<xml>${doc}</xml>`).firstChild;
     const container = $('<div />');
 
-    $(xml).find('mark').replaceWith((idx, text) => $('<div />', {'class': 'equipment', 'text': text}));
-    const direction = $('<li />', {'html': xml.childNodes});
+    $(xml).find('mark').replaceWith((idx, text) => $('<span />', {'class': 'equipment tag badge', 'text': text}));
+    const direction = $('<li />', {'class': 'direction', 'html': xml.childNodes});
 
     container.append(direction);
     return container.html();

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -2,7 +2,7 @@ import { xsltProcess } from 'xslt-processor'
 
 import { renderQuantity } from './conversion';
 
-export { renderToHTML };
+export { renderToHTML, renderDirectionHTML };
 
 const template = `
 <?xml version="1.0" encoding="utf-8" ?>
@@ -65,4 +65,15 @@ function renderToHTML(doc, state) {
     recipeHTML.find('div.quantity').html(quantityText);
 
     return recipeHTML.children().get().map(node => node.outerHTML).join('');
+}
+
+function renderDirectionHTML(doc) {
+    const xml = $.parseXML(`<xml>${doc}</xml>`).firstChild;
+    const container = $('<div />');
+
+    $(xml).find('mark').replaceWith((idx, text) => $('<div />', {'class': 'equipment', 'text': text}));
+    const direction = $('<li />', {'html': xml.childNodes});
+
+    container.append(direction);
+    return container.html();
 }

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -6,7 +6,7 @@ import 'tablesaw/dist/stackonly/tablesaw.stackonly.css';
 import './recipe-list.css'
 
 import { float2rat, getRecipe } from '../common';
-import { renderToHTML } from '../recipeml';
+import { renderToHTML, renderDirectionToHTML } from '../recipeml';
 import { getState, pushState } from '../state';
 import { storage } from '../storage';
 import { addRecipe } from '../models/recipes';
@@ -20,38 +20,6 @@ export {
     updateRecipeState,
     updateStarState,
 };
-
-function renderTokens(tokens) {
-  return tokens.map(renderToken).join('');
-}
-
-function renderToken(token) {
-  switch (token.type) {
-    case 'text': return renderText(token);
-    case 'product': return renderProduct(token);
-    case 'quantity': return renderQuantity(token);
-    case 'units': return renderUnits(token);
-    default: return '';
-  }
-}
-
-function renderText(token) {
-  if (!token.value) return '';
-  return token.value;
-}
-
-function renderProduct(token) {
-  return '<span class="tag badge ' + token.state + '">' + token.value + '</span>';
-}
-
-function renderQuantity(token) {
-  if (!token.value) return '';
-  return float2rat(token.value);
-}
-
-function renderUnits(token) {
-  return renderText(token);
-}
 
 function titleFormatter(recipe) {
   var title = $('<div />', {'class': 'title'});
@@ -113,7 +81,7 @@ function contentFormatter(recipe) {
   var directions = $('<div />', {'class': 'tab directions collapse'});
   var directionList = $('<ul />');
   $.each(recipe.directions, function() {
-    directionList.append($('<li />', {'html': renderTokens(this.tokens)}));
+    directionList.append(renderDirectionToHTML(this.markup));
   });
   directions.append(directionList);
   content.append(directions);

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -6,7 +6,7 @@ import 'tablesaw/dist/stackonly/tablesaw.stackonly.css';
 import './recipe-list.css'
 
 import { getRecipe } from '../common';
-import { renderIngredientHTML, renderDirectionToHTML } from '../recipeml';
+import { renderIngredientHTML, renderDirectionHTML } from '../recipeml';
 import { getState, pushState } from '../state';
 import { storage } from '../storage';
 import { addRecipe } from '../models/recipes';
@@ -81,7 +81,7 @@ function contentFormatter(recipe) {
   var directions = $('<div />', {'class': 'tab directions collapse'});
   var directionList = $('<ul />');
   $.each(recipe.directions, function() {
-    directionList.append(renderDirectionToHTML(this.markup));
+    directionList.append(renderDirectionHTML(this.markup));
   });
   directions.append(directionList);
   content.append(directions);

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -6,7 +6,7 @@ import 'tablesaw/dist/stackonly/tablesaw.stackonly.css';
 import './recipe-list.css'
 
 import { float2rat, getRecipe } from '../common';
-import { renderToHTML, renderDirectionToHTML } from '../recipeml';
+import { renderIngredientHTML, renderDirectionToHTML } from '../recipeml';
 import { getState, pushState } from '../state';
 import { storage } from '../storage';
 import { addRecipe } from '../models/recipes';
@@ -68,7 +68,7 @@ function contentFormatter(recipe) {
   var ingredients = $('<div />', {'class': 'tab ingredients'});
   var ingredientList = $('<div  />');
   $.each(recipe.ingredients, function() {
-    ingredientList.append(renderToHTML(this.markup, this.state));
+    ingredientList.append(renderIngredientHTML(this.markup, this.state));
     ingredientList.append($('<div  />', {'style': 'clear: both'}));
   });
   ingredients.append(ingredientList);

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -5,7 +5,7 @@ import 'tablesaw/dist/stackonly/tablesaw.stackonly.jquery.js';
 import 'tablesaw/dist/stackonly/tablesaw.stackonly.css';
 import './recipe-list.css'
 
-import { float2rat, getRecipe } from '../common';
+import { getRecipe } from '../common';
 import { renderIngredientHTML, renderDirectionToHTML } from '../recipeml';
 import { getState, pushState } from '../state';
 import { storage } from '../storage';

--- a/test/recipeml.js
+++ b/test/recipeml.js
@@ -64,7 +64,7 @@ describe('html rendering', function() {
 
   it('renders simple direction', function() {
     var recipeML = 'place the <mark>casserole dish</mark> in the <mark>oven</mark>';
-    var expected = '<li>place the <div class="equipment">casserole dish</div> in the <div class="equipment">oven</div></li>';
+    var expected = '<li class="direction">place the <span class="equipment tag badge">casserole dish</span> in the <span class="equipment tag badge">oven</span></li>';
 
     var rendered = renderDirectionHTML(recipeML);
 

--- a/test/recipeml.js
+++ b/test/recipeml.js
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 
-import { renderToHTML } from '../src/app/recipeml';
+import { renderToHTML, renderDirectionHTML } from '../src/app/recipeml';
 
 function recipeMLHelper(ingredient, product_id, quantity, units, preamble, postamble) {
     return `<amt><qty>${quantity}</qty><unit>${units}</unit></amt>${preamble}<ingredient href="products/${product_id}">${ingredient}</ingredient>${postamble}`;
@@ -58,6 +58,15 @@ describe('html rendering', function() {
     var expected = '<div class="quantity"></div><div class="product"><span class="tag badge available">garlic</span></div>';
 
     var rendered = renderToHTML(recipeML, 'available');
+
+    assert.equal(expected, rendered);
+  });
+
+  it('renders simple direction', function() {
+    var recipeML = 'place the <mark>casserole dish</mark> in the <mark>oven</mark>';
+    var expected = '<li>place the <div class="equipment">casserole dish</div> in the <div class="equipment">oven</div></li>';
+
+    var rendered = renderDirectionHTML(recipeML);
 
     assert.equal(expected, rendered);
   });

--- a/test/recipeml.js
+++ b/test/recipeml.js
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 
-import { renderToHTML, renderDirectionHTML } from '../src/app/recipeml';
+import { renderIngredientHTML, renderDirectionHTML } from '../src/app/recipeml';
 
 function recipeMLHelper(ingredient, product_id, quantity, units, preamble, postamble) {
     return `<amt><qty>${quantity}</qty><unit>${units}</unit></amt>${preamble}<ingredient href="products/${product_id}">${ingredient}</ingredient>${postamble}`;
@@ -12,7 +12,7 @@ describe('html rendering', function() {
     var recipeML = '<amt><qty>0.5</qty><unit>bag</unit></amt><ingredient>potato wedges</ingredient>';
     var expected = '<div class="quantity"><sup>1</sup>⁄<sub>2</sub> bag</div><div class="product"><span class="tag badge">potato wedges</span></div>';
 
-    var rendered = renderToHTML(recipeML);
+    var rendered = renderIngredientHTML(recipeML);
 
     assert.equal(expected, rendered);
   });
@@ -21,7 +21,7 @@ describe('html rendering', function() {
     var recipeML = '<amt><qty>1</qty><unit>whole</unit></amt>small <ingredient>onion</ingredient> diced';
     var expected = '<div class="quantity">1 whole</div><div class="product">small <span class="tag badge">onion</span> diced</div>';
 
-    var rendered = renderToHTML(recipeML);
+    var rendered = renderIngredientHTML(recipeML);
 
     assert.equal(expected, rendered);
   });
@@ -30,7 +30,7 @@ describe('html rendering', function() {
     var recipeML = '<amt><qty>1</qty></amt><ingredient>onion</ingredient>';
     var expected = '<div class="quantity">1</div><div class="product"><span class="tag badge">onion</span></div>';
 
-    var rendered = renderToHTML(recipeML);
+    var rendered = renderIngredientHTML(recipeML);
 
     assert.equal(expected, rendered);
   });
@@ -39,7 +39,7 @@ describe('html rendering', function() {
     var recipeML = '<amt><qty>14.79</qty><unit>ml</unit></amt><ingredient>olive oil</ingredient>';
     var expected = '<div class="quantity">3 teaspoons</div><div class="product"><span class="tag badge">olive oil</span></div>';
 
-    var rendered = renderToHTML(recipeML);
+    var rendered = renderIngredientHTML(recipeML);
 
     assert.equal(expected, rendered);
   });
@@ -48,7 +48,7 @@ describe('html rendering', function() {
     var recipeML = '<ingredient>bananas</ingredient>';
     var expected = '<div class="quantity"></div><div class="product"><span class="tag badge">bananas</span></div>';
 
-    var rendered = renderToHTML(recipeML);
+    var rendered = renderIngredientHTML(recipeML);
 
     assert.equal(expected, rendered);
   });
@@ -57,7 +57,7 @@ describe('html rendering', function() {
     var recipeML = '<ingredient>garlic</ingredient>';
     var expected = '<div class="quantity"></div><div class="product"><span class="tag badge available">garlic</span></div>';
 
-    var rendered = renderToHTML(recipeML, 'available');
+    var rendered = renderIngredientHTML(recipeML, 'available');
 
     assert.equal(expected, rendered);
   });


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This a companion pull request to https://github.com/openculinary/frontend/pull/127, and enables rendering of recipe directions from their source RecipeML.

In this case jQuery XML manipulation is used in preference to XSLT.

### How have the changes been tested?
1. Test coverage is provided
