### PR TITLE
Refactor: render ingredients without using XSLT

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "popper.js": "^1.16.1",
     "select2": "^4.0.13",
     "sortablejs": "^1.10.2",
-    "tablesaw": "^3.1.2",
-    "xslt-processor": "^0.11.5"
+    "tablesaw": "^3.1.2"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^3.0.0",

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -1,5 +1,3 @@
-import { xsltProcess } from 'xslt-processor'
-
 import { renderQuantity } from './conversion';
 
 export { renderIngredientHTML, renderDirectionHTML };


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The ingredient rendering introduced in #127 relies on XSL transforms, which are nice in theory but tend to be a little complicated and inefficient in practice.

This changeset is a refactor to use jQuery's native XML functionality for ingredient rendering rather than relying on an XSLT library.

### How have the changes been tested?
1. Existing test coverage continues to pass