### PR TITLE
Remove token usage

### DIFF
--- a/src/app/common.js
+++ b/src/app/common.js
@@ -25,6 +25,7 @@ function getRecipeProducts(recipe) {
   recipe.ingredients.forEach(function(ingredient) {
     var quantity = getIngredientQuantity(ingredient.markup);
     recipeProducts.push({
+      product_id: ingredient.product.product_id,
       product: ingredient.product.product,
       category: ingredient.product.category,
       singular: ingredient.product.singular,

--- a/src/app/common.js
+++ b/src/app/common.js
@@ -1,5 +1,6 @@
 import 'jquery';
 
+import { getIngredientQuantity } from './recipeml';
 import { storage } from './storage';
 export { float2rat, getRecipe, getRecipeById };
 
@@ -22,21 +23,15 @@ function getRecipeById(recipeId) {
 function getRecipeProducts(recipe) {
   var recipeProducts = [];
   recipe.ingredients.forEach(function(ingredient) {
-    var productToken, quantityToken, unitsToken;
-    ingredient.tokens.forEach(function(token) {
-      if (token.type == 'product') productToken = token;
-      if (token.type == 'quantity') quantityToken = token;
-      if (token.type == 'units') unitsToken = token;
-    });
-
+    var quantity = getIngredientQuantity(ingredient.markup);
     recipeProducts.push({
-      product: productToken.value,
-      category: productToken.category,
-      singular: productToken.singular,
-      plural: productToken.plural,
-      state: productToken.state,
-      quantity: quantityToken ? quantityToken.value : null,
-      units: unitsToken ? unitsToken.value : null
+      product: ingredient.product.product,
+      category: ingredient.product.category,
+      singular: ingredient.product.singular,
+      plural: ingredient.product.plural,
+      state: ingredient.product.state,
+      quantity: quantity.magnitude,
+      units: quantity.units,
     });
   });
   return recipeProducts;

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -2,21 +2,23 @@ import { renderQuantity } from './conversion';
 
 export { renderIngredientHTML, renderDirectionHTML };
 
+function getIngredientQuantity(doc) {
+    const xml = $.parseXML(`<xml>${doc}</xml>`).firstChild;
+    return {
+      magnitude: Number($(xml).find('amt qty').text()),
+      units: $(xml).find('amt unit').text(),
+    };
+}
+
 function renderIngredientHTML(doc, state) {
     const xml = $.parseXML(`<xml>${doc}</xml>`).firstChild;
     const container = $('<div />');
 
-    const magnitude = Number($(xml).find('amt qty').text());
-    const units = $(xml).find('amt unit').text();
-    $(xml.childNodes).remove('amt');
-
-    const quantity = renderQuantity({
-      magnitude: magnitude,
-      units: units,
-    });
+    const quantity = renderQuantity(getIngredientQuantity(doc));
     const quantityHTML = `${quantity.magnitude || ''} ${quantity.units || ''}`.trim();
     container.append($('<div />', {'class': 'quantity', 'html': quantityHTML}));
 
+    $(xml.childNodes).remove('amt');
     $(xml).find('ingredient').replaceWith((idx, text) => $('<span />', {'class': `tag badge`, 'text': text}).addClass(state));
     container.append($('<div />', {'class': 'product', 'html': xml.childNodes}));
 

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -1,6 +1,6 @@
 import { renderQuantity } from './conversion';
 
-export { renderIngredientHTML, renderDirectionHTML };
+export { getIngredientQuantity, renderIngredientHTML, renderDirectionHTML };
 
 function getIngredientQuantity(doc) {
     const xml = $.parseXML(`<xml>${doc}</xml>`).firstChild;


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The `tokens` search API response field for ingredients and directions is deprecated, and we should prefer to read ingredient and product metadata from the `ingredient` response objects.

### How have the changes been tested?
1. Tested using a development instance of the application