### PR TITLE
Cleanup: remove unused refinement functionality

### DIFF
--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -69,14 +69,6 @@ function renderRefinement(refinement) {
       'data-i18n': '[html]search:refinement-partial-results'
     });
   }
-  if (refinement.startsWith('removed:')) {
-    var product = refinement.split(':')[1];
-    $('#include').next('.select2').find(`li[title~='${product}']`).css('text-decoration', 'line-through');
-    return $('<div />', {
-      'data-i18n': '[html]search:refinement-ingredient-removed',
-      'data-i18n-options': JSON.stringify({product: product})
-    });
-  }
 }
 
 function emptyResultHandler(data) {


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This code is unreachable now that refinement-by-ingredient-removal no longer takes place (see openculinary/api#62)

**List any issues that this change relates to**
Relates to openculinary/api#42
