### PR TITLE
Use 'product_id' as key for product storage and equality comparison

### DIFF
--- a/src/app/autosuggest.js
+++ b/src/app/autosuggest.js
@@ -32,7 +32,7 @@ function bindIngredientInput(element, label, placeholder) {
       data: params => ({pre: params.term}),
       processResults: data => ({
         results: data.map(item => ({
-          id: item.singular,
+          id: item.product_id,
           text: item.product,
           product: item
         }))

--- a/src/app/models/products.js
+++ b/src/app/models/products.js
@@ -22,8 +22,8 @@ function aggregateUnitQuantities(product, mealCounts) {
 
 function addProduct(product, recipeId) {
   var products = storage.products.load();
-  if (product.singular in products) {
-    product.category = products[product.singular].category;
+  if (product.product_id in products) {
+    product.category = products[product.product_id].category;
   }
   if (!product.state) {
     product.state = 'required';
@@ -42,13 +42,13 @@ function addProduct(product, recipeId) {
     });
   }
 
-  storage.products.remove({'hashCode': product.singular});
-  storage.products.add({'hashCode': product.singular, 'value': product});
+  storage.products.remove({'hashCode': product.product_id});
+  storage.products.add({'hashCode': product.product_id, 'value': product});
 }
 
 function removeProduct(product, recipeId) {
   if (recipeId) delete product.recipes[recipeId];
   if (Object.keys(product.recipes).length) return;
 
-  storage.products.remove({'hashCode': product.singular});
+  storage.products.remove({'hashCode': product.product_id});
 }

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -48,20 +48,20 @@ function toggleProductState() {
   };
   product.state = transitions[product.state];
 
-  storage.products.remove({'hashCode': product.singular});
-  storage.products.add({'hashCode': product.singular, 'value': product});
+  storage.products.remove({'hashCode': product.product_id});
+  storage.products.add({'hashCode': product.product_id, 'value': product});
 }
 
 function productElement(product, mealCounts) {
   var label = $('<label />', {
     'class': 'product',
-    'data-id': product.singular,
+    'data-id': product.product_id,
     'click': toggleProductState
   });
   $('<input />', {
     'type': 'checkbox',
     'name': 'products[]',
-    'value': product.singular,
+    'value': product.product_id,
     'checked': ['available', 'purchased'].includes(product.state)
   }).appendTo(label);
 
@@ -148,7 +148,7 @@ function bindShoppingListInput(element, placeholder) {
       data: params => ({pre: params.term}),
       processResults: data => ({
         results: data.map(item => ({
-          id: item.singular,
+          id: item.product_id,
           text: item.product,
           product: item
         }))
@@ -163,7 +163,7 @@ function bindShoppingListInput(element, placeholder) {
 
     var products = storage.products.load();
     var product = event.params.data.product;
-    if (product.singular in products) return;
+    if (product.product_id in products) return;
 
     addProduct(product);
   });


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This change migrates the frontend application to use the `product.product_id` field as the key for product storage and equality comparisons.

This field should be more stable than the human-readable `product.singular` field that has been used previously.

### How have the changes been tested?
1. Existing unit tests continue to pass