### PR TITLE
Bugfix: continue to use product.singular as userspace ingredient search value

### DIFF
--- a/src/app/autosuggest.js
+++ b/src/app/autosuggest.js
@@ -32,7 +32,7 @@ function bindIngredientInput(element, label, placeholder) {
       data: params => ({pre: params.term}),
       processResults: data => ({
         results: data.map(item => ({
-          id: item.product_id,
+          id: item.singular,
           text: item.product,
           product: item
         }))

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -14,12 +14,20 @@ export { renderSearch, renderIndividual };
 
 function pushSearch() {
   var state = {'action': 'search'};
-  ['#include', '#exclude', '#equipment'].forEach(function (element) {
+  // TODO: Reconsolidate the ingredient and equipment loops
+  ['#equipment'].forEach(function (element) {
     var fragment = element.replace('#', '');
     var data = $(element).val();
     if (data.length > 0) {
       state[fragment] = data.join(',');
     }
+  ['#include', '#exclude'].forEach(function (element) {
+    var fragment = element.replace('#', '');
+    var data = $(element).select2("data");
+    if (data.length > 0) {
+      state[fragment] = data.map(item => item.product.singular).join(',');
+    }
+  })
   })
   var sortChoice = getState().sort;
   if (sortChoice) state['sort'] = sortChoice;
@@ -36,9 +44,10 @@ function pushSearch() {
 $('#search form button').on('click', pushSearch);
 
 function renderSearch() {
+  // TODO: Reconsolidate ingredient and equipment parameter construction
   var params = {
-    include: $('#include').val(),
-    exclude: $('#exclude').val(),
+    include: $('#include').select2("data").map(item => item.product.singular),
+    exclude: $('#exclude').select2("data").map(item => item.product.singular),
     equipment: $('#equipment').val(),
   };
 

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -14,20 +14,12 @@ export { renderSearch, renderIndividual };
 
 function pushSearch() {
   var state = {'action': 'search'};
-  // TODO: Reconsolidate the ingredient and equipment loops
-  ['#equipment'].forEach(function (element) {
+  ['#include', '#exclude', '#equipment'].forEach(function (element) {
     var fragment = element.replace('#', '');
     var data = $(element).val();
     if (data.length > 0) {
       state[fragment] = data.join(',');
     }
-  ['#include', '#exclude'].forEach(function (element) {
-    var fragment = element.replace('#', '');
-    var data = $(element).select2("data");
-    if (data.length > 0) {
-      state[fragment] = data.map(item => item.product.singular).join(',');
-    }
-  })
   })
   var sortChoice = getState().sort;
   if (sortChoice) state['sort'] = sortChoice;
@@ -44,10 +36,9 @@ function pushSearch() {
 $('#search form button').on('click', pushSearch);
 
 function renderSearch() {
-  // TODO: Reconsolidate ingredient and equipment parameter construction
   var params = {
-    include: $('#include').select2("data").map(item => item.product.singular),
-    exclude: $('#exclude').select2("data").map(item => item.product.singular),
+    include: $('#include').val(),
+    exclude: $('#exclude').val(),
     equipment: $('#equipment').val(),
   };
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Although `product.product_id` serves well for unique identification of products within the internals of the system, for the purposes of human-readable URL sharing and search API methods, `product.singular` is a better choice.

### Briefly summarize the changes
1. Switch the autosuggest fields in the client application to bind to `product.singular` (as they did prior to #135)