### PR TITLE
Improve hint messaging in the meal planner

### DIFF
--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -29,10 +29,14 @@ function filterMeals(meals) {
 }
 
 function updateHints(meals) {
-    var hints = $('#meal-planner div.hints').empty();
-    var hint = i18nAttr('meal-planner:feature-introduction');
-    if (meals.length) hint = i18nAttr('meal-planner:hint-drag');
-    hints.append($('<p />', {'data-i18n': hint}));
+    var hints = [];
+    if (meals.length) {
+        hints.push($('<p />', {'data-i18n': i18nAttr('meal-planner:hint-drag')}));
+    } else {
+        hints.push($('<p />', {'data-i18n': i18nAttr('meal-planner:empty-meal-planner')}));
+        hints.push($('<p />', {'data-i18n': i18nAttr('meal-planner:feature-introduction')}));
+    }
+    $('#meal-planner div.hints').empty().append(hints);
 }
 
 function renderMeals() {

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -30,7 +30,7 @@ function filterMeals(meals) {
 
 function updateHints(meals) {
     var hints = [];
-    if (meals.length) {
+    if (Object.keys(meals).length) {
         hints.push($('<p />', {'data-i18n': i18nAttr('meal-planner:hint-drag')}));
     } else {
         hints.push($('<p />', {'data-i18n': i18nAttr('meal-planner:empty-meal-planner')}));

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -6,6 +6,7 @@ import i18next from 'i18next';
 import './meals.css';
 
 import { getRecipe } from '../common';
+import { i18nAttr } from '../i18n';
 import { storage } from '../storage';
 import { removeMeal } from '../models/meals';
 import { removeRecipe } from '../models/recipes';
@@ -27,10 +28,19 @@ function filterMeals(meals) {
   return meals;
 }
 
+function updateHints(meals) {
+    var hints = $('#meal-planner div.hints').empty();
+    var hint = i18nAttr('meal-planner:feature-introduction');
+    if (meals.length) hint = i18nAttr('meal-planner:hint-drag');
+    hints.append($('<p />', hint));
+}
+
 function renderMeals() {
   var meals = filterMeals(storage.meals.load());
   var idxDate = defaultDate();
   var endDate = defaultDate().add(1, 'week');
+
+  updateHints(meals);
 
   var scheduler = $('#meal-planner table').empty();
   for (; idxDate < endDate; idxDate.add(1, 'day')) {

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -28,9 +28,10 @@ function filterMeals(meals) {
   return meals;
 }
 
-function updateHints(meals) {
+function updateHints() {
+    var recipes = storage.recipes.load();
     var hints = [];
-    if (Object.keys(meals).length) {
+    if (Object.keys(recipes).length) {
         hints.push($('<p />', {'data-i18n': i18nAttr('meal-planner:hint-drag')}));
     } else {
         hints.push($('<p />', {'data-i18n': i18nAttr('meal-planner:empty-meal-planner')}));
@@ -41,11 +42,11 @@ function updateHints(meals) {
 }
 
 function renderMeals() {
+  updateHints();
+
   var meals = filterMeals(storage.meals.load());
   var idxDate = defaultDate();
   var endDate = defaultDate().add(1, 'week');
-
-  updateHints(meals);
 
   var scheduler = $('#meal-planner table').empty();
   for (; idxDate < endDate; idxDate.add(1, 'day')) {

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -37,7 +37,7 @@ function updateHints(meals) {
         hints.push($('<p />', {'data-i18n': i18nAttr('meal-planner:feature-introduction')}));
     }
     $('#meal-planner div.hints').empty().append(hints);
-    localize('#mea-planner div.hints');
+    localize('#meal-planner div.hints');
 }
 
 function renderMeals() {

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -32,7 +32,7 @@ function updateHints(meals) {
     var hints = $('#meal-planner div.hints').empty();
     var hint = i18nAttr('meal-planner:feature-introduction');
     if (meals.length) hint = i18nAttr('meal-planner:hint-drag');
-    hints.append($('<p />', hint));
+    hints.append($('<p />', {'data-i18n': hint}));
 }
 
 function renderMeals() {

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -6,7 +6,7 @@ import i18next from 'i18next';
 import './meals.css';
 
 import { getRecipe } from '../common';
-import { i18nAttr } from '../i18n';
+import { i18nAttr, localize } from '../i18n';
 import { storage } from '../storage';
 import { removeMeal } from '../models/meals';
 import { removeRecipe } from '../models/recipes';
@@ -37,6 +37,7 @@ function updateHints(meals) {
         hints.push($('<p />', {'data-i18n': i18nAttr('meal-planner:feature-introduction')}));
     }
     $('#meal-planner div.hints').empty().append(hints);
+    localize('#mea-planner div.hints');
 }
 
 function renderMeals() {

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -6,7 +6,7 @@ import 'bootstrap-table/dist/bootstrap-table.css';
 import './search.css';
 
 import '../autosuggest';
-import { localize } from '../i18n';
+import { i18nAttr, localize } from '../i18n';
 import { getState, pushState } from '../state';
 import { initTable, bindLoadEvent } from '../ui/recipe-list';
 
@@ -61,12 +61,12 @@ function renderIndividual() {
 function renderRefinement(refinement) {
   if (refinement == 'empty_query') {
     return $('<div />', {
-      'data-i18n': '[html]search:refinement-empty-query'
+      'data-i18n': i18nAttr('search:refinement-empty-query')
     });
   }
   if (refinement == 'match_any') {
     return $('<div />', {
-      'data-i18n': '[html]search:refinement-partial-results'
+      'data-i18n': i18nAttr('search:refinement-partial-results')
     });
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -129,7 +129,7 @@
       <div class="card-deck mb-4 pt-3">
         <div class="card">
           <div class="card-body">
-            <div class="hints" data-i18n="[html]meal-planner:hint-drag"></div>
+            <div class="hints" data-i18n="[html]meal-planner:feature-introduction"></div>
             <div class="recipes"></div>
             <table class="scheduler"></table>
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -129,7 +129,7 @@
       <div class="card-deck mb-4 pt-3">
         <div class="card">
           <div class="card-body">
-            <div class="hints" data-i18n="[html]meal-planner:feature-introduction"></div>
+            <div class="hints"></div>
             <div class="recipes"></div>
             <table class="scheduler"></table>
           </div>


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
As identified in #129, the 'hint' messaging in the meal planner can be unclear.

In particular, a hint to 'drag recipes' is shown before the user has added any recipes to their meal plan.

### Briefly summarize the changes
1. When the user has no recipes in their meal planner, let them know that they can add them by searching for recipes
1. Once recipes have been added to the meal plan, show the existing 'drag' hint

### How have the changes been tested?
1. Development testing is required

**List any issues that this change relates to**
Fixes #129 
