### PR TITLE
Add summary notifications to the meal planner navigation tab

### DIFF
--- a/src/app/main.css
+++ b/src/app/main.css
@@ -33,6 +33,10 @@ header span.notification {
   right: -0.2rem;
 }
 
+header span.notification.meal-planner {
+  background-color: #00af00;
+}
+
 header span.notification.shopping-list {
   background-color: #af0000;
 }

--- a/src/app/main.css
+++ b/src/app/main.css
@@ -22,7 +22,6 @@ header div.menu {
 }
 
 header span.notification {
-  background-color: #af0000;
   border-radius: 2px;
   color: white;
 
@@ -32,6 +31,10 @@ header span.notification {
   position: relative;
   top: -0.8rem;
   right: -0.2rem;
+}
+
+header span.notification.shopping-list {
+  background-color: #af0000;
 }
 
 li.select2-results__message {

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -136,12 +136,12 @@ function bindPageChange(selector) {
 
 function updateRecipeState(recipeId) {
   var recipes = storage.recipes.load();
-  var isInShoppingList = recipeId in recipes;
+  var isInRecipes = recipeId in recipes;
 
   var addButton = $(`div.recipe-list .recipe[data-id="${recipeId}"] button.add-recipe`);
-  addButton.prop('disabled', isInShoppingList);
-  addButton.toggleClass('btn-outline-primary', !isInShoppingList);
-  addButton.toggleClass('btn-outline-secondary', isInShoppingList);
+  addButton.prop('disabled', isInRecipes);
+  addButton.toggleClass('btn-outline-primary', !isInRecipes);
+  addButton.toggleClass('btn-outline-secondary', isInRecipes);
 }
 
 function updateStarState(recipeId) {

--- a/src/app/ui/recipe-list.js
+++ b/src/app/ui/recipe-list.js
@@ -74,8 +74,8 @@ function contentFormatter(recipe) {
   });
   ingredients.append(ingredientList);
   ingredients.append($('<button />', {
-    'class': 'btn btn-outline-primary add-to-shopping-list',
-    'data-i18n': i18nAttr('search:result-add-to-shopping-list')
+    'class': 'btn btn-outline-primary add-recipe',
+    'data-i18n': i18nAttr('search:result-add-recipe')
   }));
   content.append(ingredients);
 
@@ -138,7 +138,7 @@ function updateRecipeState(recipeId) {
   var recipes = storage.recipes.load();
   var isInShoppingList = recipeId in recipes;
 
-  var addButton = $(`div.recipe-list .recipe[data-id="${recipeId}"] button.add-to-shopping-list`);
+  var addButton = $(`div.recipe-list .recipe[data-id="${recipeId}"] button.add-recipe`);
   addButton.prop('disabled', isInShoppingList);
   addButton.toggleClass('btn-outline-primary', !isInShoppingList);
   addButton.toggleClass('btn-outline-secondary', isInShoppingList);
@@ -175,7 +175,7 @@ function bindPostBody(selector) {
     });
 
     $(this).find('.content .tabs a.nav-link').on('click', selectTab);
-    $(this).find('.content button.add-to-shopping-list').on('click', addRecipe);
+    $(this).find('.content button.add-recipe').on('click', addRecipe);
     $(this).parents('div.recipe-list').show();
 
     // If the user is on the page containing this table, scroll it into view

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -81,6 +81,8 @@ function renderMeals() {
       onEnd: scheduleMeal
     });
   });
+
+  populateNotifications(meals);
 }
 
 function dragMeal(evt) {
@@ -123,6 +125,16 @@ function scheduleMeal(evt) {
     storage.meals.remove({'hashCode': date});
     storage.meals.add({'hashCode': date, 'value': meals[date]});
   }
+}
+
+function populateNotifications(meals) {
+  var recipes = storage.recipes.load();
+  var empty = Object.keys(recipes).length == 0;
+  $('header span.notification.meal-planner').toggle(!empty);
+  if (empty) return;
+
+  var total = Object.keys(meals).length;
+  $('header span.notification.meal-planner').text(total);
 }
 
 $(function() {

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -81,7 +81,7 @@ function productElement(product, mealCounts) {
 
 function populateNotifications(products) {
   var empty = Object.keys(products).length == 0;
-  $('header span.notification').toggle(!empty);
+  $('header span.notification.shopping-list').toggle(!empty);
   if (empty) return;
 
   var total = 0, found = 0;
@@ -90,7 +90,7 @@ function populateNotifications(products) {
     total += 1;
     found += product.state === 'required' ? 0 : 1;
   });
-  $('header span.notification').text(found + '/' + total);
+  $('header span.notification.shopping-list').text(found + '/' + total);
 }
 
 function getProductsByCategory(products) {

--- a/src/index.html
+++ b/src/index.html
@@ -54,7 +54,7 @@
             <a class="nav-link" href="#starred-recipes" data-i18n="[html]navigation:starred"></a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#meal-planner" data-i18n="[html]navigation:meal-planner"></a>
+            <a class="nav-link" href="#meal-planner"><span data-i18n="[html]navigation:meal-planner"></span><span class="meal-planner notification collapse"></span></a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#shopping-list"><span data-i18n="[html]navigation:shopping-list"></span><span class="shopping-list notification collapse"></span></a>

--- a/src/index.html
+++ b/src/index.html
@@ -57,7 +57,7 @@
             <a class="nav-link" href="#meal-planner" data-i18n="[html]navigation:meal-planner"></a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#shopping-list"><span data-i18n="[html]navigation:shopping-list"></span><span class="notification collapse"></span></a>
+            <a class="nav-link" href="#shopping-list"><span data-i18n="[html]navigation:shopping-list"></span><span class="shopping-list notification collapse"></span></a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Currently the shopping list displays a notification summary indicating the number of items that are in the shopping list, and how many have already been acquired.

This changeset introduces a similar notification display for the meal planner that displays the number of upcoming planned meals.

The notification cue is only displayed after the user has added at least one recipe for meal planning purposes.

Relates to https://github.com/openculinary/frontend/issues/129#issuecomment-630101573