### PR TITLE
Add a 'recipe detail' view

### DIFF
--- a/src/app/main.js
+++ b/src/app/main.js
@@ -2,6 +2,7 @@ import '@fortawesome/fontawesome-free/css/fontawesome.min.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 
 import './dialogs/about';
+import './views/recipe';
 import './views/search';
 import './views/starred';
 import './views/meals';

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -2,7 +2,7 @@ import 'jquery';
 
 import { renderSearch, renderIndividual } from './views/search';
 
-export { getState, pushState };
+export { getState, loadPage, pushState };
 
 function getState() {
   if (!history.state && !location.hash) return {'search': null};

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -1,6 +1,7 @@
 import 'jquery';
 
-import { renderSearch, renderIndividual } from './views/search';
+import { renderRecipe } from './views/recipe';
+import { renderSearch } from './views/search';
 
 export { getState, loadPage, pushState };
 
@@ -72,7 +73,7 @@ function loadState() {
   if (!activeTab) {
     switch (state.action) {
       case 'search': renderSearch(); break;
-      case 'view': renderIndividual(); break;
+      case 'view': renderRecipe(); break;
     }
   }
 }

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -92,33 +92,6 @@ div.recipe-list .content span.tag.badge {
   white-space: normal;
 }
 
-div.recipe-list .content .tabs a {
-  background-color: #f0f0f0;
-  font-size: 0.75rem;
-}
-
-div.recipe-list .content .tabs a.active {
-  background-color: #fafafa;
-  font-weight: bold;
-
-  border-top: solid 1px silver;
-  border-left: solid 1px silver;
-  border-right: solid 1px silver;
-
-  margin-bottom: -1px;
-}
-
-div.recipe-list .content .tab {
-  background-color: #fafafa;
-  padding: 0.75rem;
-
-  border: solid 1px silver;
-}
-
-div.recipe-list .content .tab button {
-  margin-top: 1rem;
-}
-
 div.recipe-list .content .ingredients .quantity {
   clear: both;
   float: left;

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -94,6 +94,8 @@ div.recipe-list .content span.tag.badge {
 
 div.recipe-list .content .ingredients {
   display: grid;
+  grid-row-gap: 0.25em;
+  grid-column-gap: 0.5em;
   grid-template-columns: fit-content(25%) auto;
 }
 

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -95,7 +95,7 @@ div.recipe-list .content span.tag.badge {
 div.recipe-list .content .ingredients .quantity {
   clear: both;
   float: left;
-  width: 120px;
+  width: 60px;
   text-align: right;
 
   padding: 2px;

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -92,17 +92,16 @@ div.recipe-list .content span.tag.badge {
   white-space: normal;
 }
 
-div.recipe-list .content .ingredients .quantity {
-  clear: both;
-  float: left;
-  width: 60px;
-  text-align: right;
+div.recipe-list .content .ingredients {
+  display: grid;
+  grid-template-columns: fit-content(25%) auto;
+}
 
-  padding: 2px;
+div.recipe-list .content .ingredients .quantity {
+  grid-column: 1;
+  text-align: right;
 }
 
 div.recipe-list .content .ingredients .product {
-  float: left;
-
-  padding: 2px;
+  grid-column: 2;
 }

--- a/src/app/views/components/recipe-list.js
+++ b/src/app/views/components/recipe-list.js
@@ -63,21 +63,11 @@ function sidebarFormatter(recipe) {
 function contentFormatter(recipe) {
   var content = $('<td />', {'class': 'content align-top'});
 
-  var tabs = $('<div />', {'class': 'nav tabs'});
-  tabs.append($('<a />', {
-    'class': 'nav-link active',
-    'data-i18n': i18nAttr('search:result-tab-ingredients'),
-    'data-target': 'ingredients'
-  }));
-  content.append(tabs);
-
-  var ingredients = $('<div />', {'class': 'tab ingredients'});
-  var ingredientList = $('<div  />');
+  var ingredients = $('<div  />', {'class': 'ingredients'});
   $.each(recipe.ingredients, function() {
-    ingredientList.append(renderIngredientHTML(this.markup, this.product.state));
-    ingredientList.append($('<div  />', {'style': 'clear: both'}));
+    ingredients.append(renderIngredientHTML(this.markup, this.product.state));
+    ingredients.append($('<div  />', {'style': 'clear: both'}));
   });
-  ingredients.append(ingredientList);
   content.append(ingredients);
 
   return content;
@@ -149,17 +139,6 @@ function updateStarState(recipeId) {
   star.on('click', isStarred ? unstarRecipe : starRecipe);
 }
 
-function selectTab() {
-  var recipe = getRecipe(this);
-  var target = $(this).data('target');
-  var recipeList = $(this).parents('table[data-row-attributes]');
-
-  $(recipeList).find(`.recipe[data-id="${recipe.id}"] div.tabs a`).removeClass('active');
-  $(recipeList).find(`.recipe[data-id="${recipe.id}"] div.tabs a[data-target="${target}"]`).addClass('active');
-  $(recipeList).find(`.recipe[data-id="${recipe.id}"] div.tab`).addClass('collapse');
-  $(recipeList).find(`.recipe[data-id="${recipe.id}"] div.tab.${target}`).removeClass('collapse');
-}
-
 function bindPostBody(selector) {
   $(`${selector} table[data-row-attributes]`).on('post-body.bs.table', function(e, data) {
     data.forEach(function (row) {
@@ -167,7 +146,6 @@ function bindPostBody(selector) {
       updateStarState(row.id);
     });
 
-    $(this).find('.content .tabs a.nav-link').on('click', selectTab);
     $(this).find('.sidebar button.add-recipe').on('click', addRecipe);
     $(this).parents('div.recipe-list').show();
 

--- a/src/app/views/components/recipe-list.js
+++ b/src/app/views/components/recipe-list.js
@@ -51,6 +51,12 @@ function sidebarFormatter(recipe) {
   $('<br />').appendTo(sidebar);
   $('<span />', {'html': '<strong>time</strong>'}).appendTo(sidebar);
   $('<span />', {'text': duration.as('minutes') + ' mins'}).appendTo(sidebar);
+
+  sidebar.append($('<button />', {
+    'class': 'btn btn-outline-primary add-recipe',
+    'data-i18n': i18nAttr('search:result-add-recipe')
+  }));
+
   return sidebar;
 }
 
@@ -72,10 +78,6 @@ function contentFormatter(recipe) {
     ingredientList.append($('<div  />', {'style': 'clear: both'}));
   });
   ingredients.append(ingredientList);
-  ingredients.append($('<button />', {
-    'class': 'btn btn-outline-primary add-recipe',
-    'data-i18n': i18nAttr('search:result-add-recipe')
-  }));
   content.append(ingredients);
 
   return content;
@@ -166,7 +168,7 @@ function bindPostBody(selector) {
     });
 
     $(this).find('.content .tabs a.nav-link').on('click', selectTab);
-    $(this).find('.content button.add-recipe').on('click', addRecipe);
+    $(this).find('.sidebar button.add-recipe').on('click', addRecipe);
     $(this).parents('div.recipe-list').show();
 
     // If the user is on the page containing this table, scroll it into view

--- a/src/app/views/components/recipe-list.js
+++ b/src/app/views/components/recipe-list.js
@@ -118,8 +118,14 @@ function bindPageChange(selector) {
     if (number > 1) state.page = number;
     else delete state.page;
 
+    // Record the page the user was on in the state
+    var page = selector.substring(1);
+    if (page === 'search') state['action'] = page;
+    delete state[page];
     var stateHash = decodeURIComponent($.param(state));
-    pushState(state, `${selector}&${stateHash}`);
+    state[page] = null;
+
+    pushState(state, `#${page}&${stateHash}`);
 
     scrollToResults(selector, 50);
   });

--- a/src/app/views/components/recipe-list.js
+++ b/src/app/views/components/recipe-list.js
@@ -52,6 +52,14 @@ function sidebarFormatter(recipe) {
   $('<span />', {'html': '<strong>time</strong>'}).appendTo(sidebar);
   $('<span />', {'text': duration.as('minutes') + ' mins'}).appendTo(sidebar);
 
+  // TODO: i18n
+  var destination = $('<a />', {'href': recipe.dst});
+  destination.append($('<button />', {
+    'class': 'btn btn-outline-primary',
+    'text': `View on ${recipe.domain}`
+  }));
+  sidebar.append(destination);
+
   sidebar.append($('<button />', {
     'class': 'btn btn-outline-primary add-recipe',
     'data-i18n': i18nAttr('search:result-add-recipe')

--- a/src/app/views/components/recipe-list.js
+++ b/src/app/views/components/recipe-list.js
@@ -119,7 +119,7 @@ function bindPageChange(selector) {
     else delete state.page;
 
     var stateHash = decodeURIComponent($.param(state));
-    pushState(state, `#${stateHash}`);
+    pushState(state, `${selector}&${stateHash}`);
 
     scrollToResults(selector, 50);
   });

--- a/src/app/views/components/recipe-list.js
+++ b/src/app/views/components/recipe-list.js
@@ -7,7 +7,7 @@ import './recipe-list.css'
 
 import { getRecipe } from '../../common';
 import { i18nAttr, localize } from '../../i18n';
-import { renderIngredientHTML, renderDirectionHTML } from '../../recipeml';
+import { renderIngredientHTML } from '../../recipeml';
 import { getState, pushState } from '../../state';
 import { storage } from '../../storage';
 import { addRecipe } from '../../models/recipes';
@@ -63,11 +63,6 @@ function contentFormatter(recipe) {
     'data-i18n': i18nAttr('search:result-tab-ingredients'),
     'data-target': 'ingredients'
   }));
-  tabs.append($('<a />', {
-    'class': 'nav-link',
-    'data-i18n': i18nAttr('search:result-tab-directions'),
-    'data-target': 'directions'
-  }));
   content.append(tabs);
 
   var ingredients = $('<div />', {'class': 'tab ingredients'});
@@ -82,14 +77,6 @@ function contentFormatter(recipe) {
     'data-i18n': i18nAttr('search:result-add-recipe')
   }));
   content.append(ingredients);
-
-  var directions = $('<div />', {'class': 'tab directions collapse'});
-  var directionList = $('<ul />');
-  $.each(recipe.directions, function() {
-    directionList.append(renderDirectionHTML(this.markup));
-  });
-  directions.append(directionList);
-  content.append(directions);
 
   return content;
 }

--- a/src/app/views/components/recipe-list.js
+++ b/src/app/views/components/recipe-list.js
@@ -41,7 +41,11 @@ function starFormatter() {
 function sidebarFormatter(recipe) {
   var duration = moment.duration(recipe.time, 'minutes');
   var sidebar = $('<td />', {'class': 'sidebar align-top'});
-  $('<img />', {'src': recipe.image_url, 'alt': recipe.title}).appendTo(sidebar);
+
+  var link = $('<a />', {'href': `#search&action=view&id=${recipe.id}`});
+  $('<img />', {'src': recipe.image_url, 'alt': recipe.title}).appendTo(link);
+  link.appendTo(sidebar);
+
   $('<span />', {'html': '<strong>serves</strong>'}).appendTo(sidebar);
   $('<span />', {'text': recipe.servings}).appendTo(sidebar);
   $('<br />').appendTo(sidebar);

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -5,6 +5,13 @@
   grid-column-gap: 1em;
 }
 
+#recipe div.title {
+  font-weight: bold;
+  font-size: large;
+  color: #006;
+  padding: 1em;
+}
+
 #recipe div.contents div.image {
   grid-row: 1;
   grid-column: 1;

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -1,6 +1,6 @@
 #recipe div.contents {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: minmax(20%, 30%) auto;
   grid-row-gap: 1em;
   grid-column-gap: 1em;
 }

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -1,10 +1,3 @@
-#recipe div.contents {
-  display: grid;
-  grid-template-columns: minmax(20%, 30%) auto;
-  grid-row-gap: 1em;
-  grid-column-gap: 1em;
-}
-
 #recipe div.title {
   font-weight: bold;
   font-size: 24px;
@@ -14,11 +7,18 @@
   padding-left: 2em;
 }
 
-#recipe div.contents div.image {
-  grid-row: 1;
-  grid-column: 1;
+#recipe div.contents {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, max-content));
+  grid-row-gap: 1em;
+  grid-column-gap: 1em;
+}
 
+#recipe div.contents div.image {
   padding: 2rem;
+
+  grid-column: 1 / 3;
+  text-align: center;
 }
 
 #recipe div.contents div.image img {
@@ -27,9 +27,6 @@
 }
 
 #recipe div.contents div.ingredients {
-  grid-row: 2;
-  grid-column: 1;
-
   display: grid;
   grid-row-gap: 0.25em;
   grid-column-gap: 0.5em;
@@ -62,8 +59,6 @@
 }
 
 #recipe div.contents div.directions {
-  grid-row: 2;
-  grid-column: 2;
 }
 
 #recipe div.contents div.directions li.direction {

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -69,3 +69,15 @@
 #recipe div.contents div.directions li.direction {
   padding: 0.2rem;
 }
+
+#recipe div.contents div.directions li.direction.hover {
+  background-color: #eee;
+}
+
+#recipe div.contents div.directions li.direction.mark {
+  background-color: #ee9;
+}
+
+#recipe div.contents div.directions li.direction.hover.mark {
+  background-color: #dd8;
+}

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -50,6 +50,7 @@
 
   text-align: right;
   font-weight: bold;
+  color: #006;
 }
 
 #recipe div.contents div.metadata .value {

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -15,6 +15,8 @@
 #recipe div.contents div.image {
   grid-row: 1;
   grid-column: 1;
+
+  padding: 2rem;
 }
 
 #recipe div.contents div.ingredients {

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -1,0 +1,21 @@
+#recipe div.contents {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-row-gap: 1em;
+  grid-column-gap: 1em;
+}
+
+#recipe div.contents div.image {
+  grid-row: 1;
+  grid-column: 1;
+}
+
+#recipe div.contents div.ingredients {
+  grid-row: 2;
+  grid-column: 1;
+}
+
+#recipe div.contents div.directions {
+  grid-row: 1 / 3;
+  grid-column: 2;
+}

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -65,3 +65,7 @@
   grid-row: 2;
   grid-column: 2;
 }
+
+#recipe div.contents div.directions li.direction {
+  padding: 0.2rem;
+}

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -64,6 +64,4 @@
 #recipe div.contents div.directions {
   grid-row: 2;
   grid-column: 2;
-
-  padding: 2rem;
 }

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -7,9 +7,11 @@
 
 #recipe div.title {
   font-weight: bold;
-  font-size: large;
+  font-size: 24px;
   color: #006;
-  padding: 1em;
+
+  padding-top: 1em;
+  padding-left: 2em;
 }
 
 #recipe div.contents div.image {

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -41,6 +41,7 @@
 
 #recipe div.contents div.ingredients {
   display: grid;
+  grid-auto-rows: min-content;
   grid-row-gap: 0.25em;
   grid-column-gap: 0.5em;
 }

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -14,6 +14,13 @@
   grid-column-gap: 1em;
 }
 
+#recipe div.headline {
+  grid-column: 1 / 3;
+
+  width: 100%;
+  text-align: center;
+}
+
 #recipe div.contents div.image {
   padding: 2rem;
 
@@ -26,21 +33,16 @@
   box-shadow: 2px 2px 2px 1px #ccc;
 }
 
+#recipe div.contents div.section-title {
+  font-weight: bold;
+  color: #006;
+  padding: 0.5em;
+}
+
 #recipe div.contents div.ingredients {
   display: grid;
   grid-row-gap: 0.25em;
   grid-column-gap: 0.5em;
-}
-
-#recipe div.contents div.ingredients .heading {
-  grid-column: 1 / 3;
-
-  width: 100%;
-  text-align: center;
-
-  font-weight: bold;
-  color: #006;
-  padding: 0.5em;
 }
 
 #recipe div.contents div.ingredients .quantity {
@@ -50,15 +52,6 @@
 
 #recipe div.contents div.ingredients .product {
   grid-column: 2;
-}
-
-#recipe div.contents div.directions .heading {
-  font-weight: bold;
-  color: #006;
-  padding: 0.5em;
-}
-
-#recipe div.contents div.directions {
 }
 
 #recipe div.contents div.directions li.direction {

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -40,4 +40,6 @@
 #recipe div.contents div.directions {
   grid-row: 1 / 3;
   grid-column: 2;
+
+  padding: 2rem;
 }

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -14,7 +14,7 @@
   grid-column-gap: 1em;
 }
 
-#recipe div.headline {
+#recipe .headline {
   grid-column: 1 / 3;
 
   width: 100%;

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -19,6 +19,11 @@
   padding: 2rem;
 }
 
+#recipe div.contents div.image img {
+  max-width: 192px;
+  box-shadow: 2px 2px 2px 1px #ccc;
+}
+
 #recipe div.contents div.ingredients {
   grid-row: 2;
   grid-column: 1;

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -22,9 +22,9 @@
 }
 
 #recipe div.contents div.image {
-  padding: 2rem;
+  grid-column: 1;
 
-  grid-column: 1 / 3;
+  padding: 2rem;
   text-align: center;
 }
 
@@ -40,6 +40,8 @@
 }
 
 #recipe div.contents div.ingredients {
+  grid-column: 1;
+
   display: grid;
   grid-auto-rows: min-content;
   grid-row-gap: 0.25em;

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -81,6 +81,10 @@
   grid-column: 2;
 }
 
+#recipe div.contents div.ingredients .add-recipe {
+  margin-top: 1rem;
+}
+
 #recipe div.contents div.directions li.direction {
   padding: 0.2rem;
 }

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -33,6 +33,29 @@
   box-shadow: 2px 2px 2px 1px #ccc;
 }
 
+#recipe div.contents div.metadata {
+  display: grid;
+
+  grid-auto-columns: 100px;
+  grid-auto-rows: min-content;
+  grid-row-gap: 0.25em;
+  grid-column-gap: 0.5em;
+
+  padding: 2rem;
+  justify-content: right;
+}
+
+#recipe div.contents div.metadata .property {
+  grid-column: 1;
+
+  text-align: right;
+  font-weight: bold;
+}
+
+#recipe div.contents div.metadata .value {
+  grid-column: 2;
+}
+
 #recipe div.contents div.section-title {
   font-weight: bold;
   color: #006;

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -1,4 +1,6 @@
 #recipe div.title {
+  float: left;
+
   font-weight: bold;
   font-size: 24px;
   color: #006;
@@ -7,7 +9,19 @@
   padding-left: 2em;
 }
 
+#recipe .star {
+  float: right;
+
+  font-size: 24px;
+  line-height: inherit;
+
+  padding-top: 1em;
+  padding-right: 2em;
+}
+
 #recipe div.contents {
+  clear: both;
+
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, max-content));
   grid-row-gap: 1em;

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -20,6 +20,19 @@
 #recipe div.contents div.ingredients {
   grid-row: 2;
   grid-column: 1;
+
+  display: grid;
+  grid-row-gap: 0.25em;
+  grid-column-gap: 0.5em;
+}
+
+#recipe div.contents div.ingredients .quantity {
+  grid-column: 1;
+  text-align: right;
+}
+
+#recipe div.contents div.ingredients .product {
+  grid-column: 2;
 }
 
 #recipe div.contents div.directions {

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -62,7 +62,7 @@
 }
 
 #recipe div.contents div.directions {
-  grid-row: 1 / 3;
+  grid-row: 2;
   grid-column: 2;
 
   padding: 2rem;

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -33,6 +33,17 @@
   grid-column-gap: 0.5em;
 }
 
+#recipe div.contents div.ingredients .heading {
+  grid-column: 1 / 3;
+
+  width: 100%;
+  text-align: center;
+
+  font-weight: bold;
+  color: #006;
+  padding: 0.5em;
+}
+
 #recipe div.contents div.ingredients .quantity {
   grid-column: 1;
   text-align: right;
@@ -40,6 +51,12 @@
 
 #recipe div.contents div.ingredients .product {
   grid-column: 2;
+}
+
+#recipe div.contents div.directions .heading {
+  font-weight: bold;
+  color: #006;
+  padding: 0.5em;
 }
 
 #recipe div.contents div.directions {

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -1,3 +1,5 @@
+import * as moment from 'moment';
+
 import './recipe.css';
 
 import { getRecipeById } from '../common';
@@ -23,9 +25,11 @@ function markDirection() {
 function renderRecipe() {
   var id = getState().id;
   var recipe = getRecipeById(id);
+  var duration = moment.duration(recipe.time, 'minutes');
 
   var title = $('#recipe div.title').empty();
   var image = $('#recipe div.image').empty();
+  var metadata = $('#recipe div.metadata').empty();
   var ingredients = $('#recipe div.ingredients').empty();
   var directions = $('#recipe div.directions').empty();
 
@@ -34,6 +38,11 @@ function renderRecipe() {
 
   title.text(recipe.title);
   image.append(link);
+
+  metadata.append($('<div />', {'class': 'property', 'text': 'servings'}));
+  metadata.append($('<div />', {'class': 'value', 'text': recipe.servings}));
+  metadata.append($('<div />', {'class': 'property', 'text': 'time'}));
+  metadata.append($('<div />', {'class': 'value', 'text': duration.as('minutes') + ' mins'}));
 
   ingredients.append($('<div />', {
     'class': 'headline section-title',

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -29,7 +29,6 @@ function renderRecipe() {
 
   $.each(recipe.ingredients, function() {
     ingredients.append(renderIngredientHTML(this.markup, this.product.state));
-    ingredients.append($('<div  />', {'style': 'clear: both'}));
   });
 
   directions.append($('<div />', {
@@ -40,7 +39,6 @@ function renderRecipe() {
   var directionList  = $('<ol />');
   $.each(recipe.directions, function() {
     directionList.append(renderDirectionHTML(this.markup));
-    directionList.append($('<div  />', {'style': 'clear: both'}));
   });
   directions.append(directionList);
 

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -1,6 +1,7 @@
 import './recipe.css';
 
 import { getRecipeById } from '../common';
+import { renderIngredientHTML, renderDirectionHTML } from '../recipeml';
 import { getState, loadPage } from '../state';
 
 export { renderRecipe };
@@ -9,7 +10,24 @@ function renderRecipe() {
   var id = getState().id;
   var recipe = getRecipeById(id);
 
-  $('#recipe div.title').text(recipe.title);
+  var title = $('#recipe div.title').empty();
+  var image = $('#recipe div.image').empty();
+  var ingredients = $('#recipe div.ingredients').empty();
+  var directions = $('#recipe div.directions').empty();
+
+  var link = $('<a />', {'href': recipe.dst});
+  $('<img />', {'src': recipe.image_url, 'alt': recipe.title}).appendTo(link);
+
+  title.text(recipe.title);
+  image.append(link);
+  $.each(recipe.ingredients, function() {
+    ingredients.append(renderIngredientHTML(this.markup, this.product.state));
+    ingredients.append($('<div  />', {'style': 'clear: both'}));
+  });
+  $.each(recipe.directions, function() {
+    directions.append(renderDirectionHTML(this.markup));
+    directions.append($('<div  />', {'style': 'clear: both'}));
+  });
 
   loadPage('recipe');
 }

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -5,6 +5,7 @@ import './recipe.css';
 import { getRecipeById } from '../common';
 import { i18nAttr, localize } from '../i18n';
 import { addRecipe } from '../models/recipes';
+import { starRecipe, unstarRecipe } from '../models/starred';
 import { renderIngredientHTML, renderDirectionHTML } from '../recipeml';
 import { getState, loadPage } from '../state';
 import { storage } from '../storage';
@@ -24,6 +25,10 @@ function markDirection() {
   $(this).addClass('mark');
 }
 
+function starFormatter() {
+  return $('<div />', {'class': 'star far fa-star'});
+}
+
 function updateRecipeState() {
   var recipes = storage.recipes.load();
   var recipeId = $('#recipe').data('id');
@@ -35,6 +40,20 @@ function updateRecipeState() {
   addButton.toggleClass('btn-outline-secondary', isInRecipes);
 }
 
+function updateStarState() {
+  var starred = storage.starred.load();
+  var recipeId = $('#recipe').data('id');
+  var isStarred = recipeId in starred;
+
+  var star = $('#recipe .star');
+  star.toggleClass('fas', isStarred);
+  star.toggleClass('far', !isStarred);
+  star.css('color', isStarred ? 'gold' : 'dimgray');
+  star.off('click');
+  star.on('click', isStarred ? unstarRecipe : starRecipe);
+  star.on('click', updateStarState);
+}
+
 function renderRecipe() {
   var id = getState().id;
   var recipe = getRecipeById(id);
@@ -42,6 +61,7 @@ function renderRecipe() {
 
   var container = $('#recipe');
   var title = $('#recipe div.title').empty();
+  var corner = $('#recipe div.corner').empty();
   var image = $('#recipe div.image').empty();
   var metadata = $('#recipe div.metadata').empty();
   var ingredients = $('#recipe div.ingredients').empty();
@@ -52,6 +72,7 @@ function renderRecipe() {
 
   container.data('id', recipe.id);
   title.text(recipe.title);
+  corner.append(starFormatter());
   image.append(link);
 
   metadata.append($('<div />', {'class': 'property', 'text': 'servings'}));
@@ -94,6 +115,8 @@ function renderRecipe() {
 
   localize('#recipe');
   loadPage('recipe');
+
+  updateStarState();
 }
 
 $(function() {

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -1,6 +1,7 @@
 import './recipe.css';
 
 import { getRecipeById } from '../common';
+import { i18nAttr, localize } from '../i18n';
 import { renderIngredientHTML, renderDirectionHTML } from '../recipeml';
 import { getState, loadPage } from '../state';
 
@@ -20,14 +21,25 @@ function renderRecipe() {
 
   title.text(recipe.title);
   image.append(link);
+
+  ingredients.append($('<div />', {
+    'class': 'heading',
+    'data-i18n': i18nAttr('search:result-tab-ingredients')
+  }));
   $.each(recipe.ingredients, function() {
     ingredients.append(renderIngredientHTML(this.markup, this.product.state));
     ingredients.append($('<div  />', {'style': 'clear: both'}));
   });
+
+  directions.append($('<div />', {
+    'class': 'heading',
+    'data-i18n': i18nAttr('search:result-tab-directions')
+  }));
   $.each(recipe.directions, function() {
     directions.append(renderDirectionHTML(this.markup));
     directions.append($('<div  />', {'style': 'clear: both'}));
   });
 
+  localize('#recipe');
   loadPage('recipe');
 }

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -1,1 +1,15 @@
 import './recipe.css';
+
+import { getRecipeById } from '../common';
+import { getState, loadPage } from '../state';
+
+export { renderRecipe };
+
+function renderRecipe() {
+  var id = getState().id;
+  var recipe = getRecipeById(id);
+
+  $('#recipe div.title').text(recipe.title);
+
+  loadPage('recipe');
+}

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -7,6 +7,19 @@ import { getState, loadPage } from '../state';
 
 export { renderRecipe };
 
+function hoverDirection() {
+  $(this).addClass('hover');
+}
+
+function unhoverDirection() {
+  $(this).removeClass('hover');
+}
+
+function markDirection() {
+  $('#recipe div.directions li.direction').removeClass('mark');
+  $(this).addClass('mark');
+}
+
 function renderRecipe() {
   var id = getState().id;
   var recipe = getRecipeById(id);
@@ -38,7 +51,11 @@ function renderRecipe() {
 
   var directionList  = $('<ol />');
   $.each(recipe.directions, function() {
-    directionList.append(renderDirectionHTML(this.markup));
+    var directionHTML = renderDirectionHTML(this.markup);
+    var direction = $(directionHTML);
+    direction.hover(hoverDirection, unhoverDirection);
+    direction.click(markDirection);
+    directionList.append(direction);
   });
   directions.append(directionList);
 

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -1,0 +1,1 @@
+import './recipe.css';

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -26,6 +26,7 @@ function renderRecipe() {
     'class': 'heading',
     'data-i18n': i18nAttr('search:result-tab-ingredients')
   }));
+
   $.each(recipe.ingredients, function() {
     ingredients.append(renderIngredientHTML(this.markup, this.product.state));
     ingredients.append($('<div  />', {'style': 'clear: both'}));
@@ -35,10 +36,13 @@ function renderRecipe() {
     'class': 'heading',
     'data-i18n': i18nAttr('search:result-tab-directions')
   }));
+
+  var directionList  = $('<ol />');
   $.each(recipe.directions, function() {
-    directions.append(renderDirectionHTML(this.markup));
-    directions.append($('<div  />', {'style': 'clear: both'}));
+    directionList.append(renderDirectionHTML(this.markup));
+    directionList.append($('<div  />', {'style': 'clear: both'}));
   });
+  directions.append(directionList);
 
   localize('#recipe');
   loadPage('recipe');

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -36,7 +36,7 @@ function renderRecipe() {
   image.append(link);
 
   ingredients.append($('<div />', {
-    'class': 'heading',
+    'class': 'headline section-title',
     'data-i18n': i18nAttr('search:result-tab-ingredients')
   }));
 
@@ -45,7 +45,7 @@ function renderRecipe() {
   });
 
   directions.append($('<div />', {
-    'class': 'heading',
+    'class': 'section-title',
     'data-i18n': i18nAttr('search:result-tab-directions')
   }));
 

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -13,7 +13,7 @@ import { initTable, bindLoadEvent } from './components/recipe-list';
 export { renderSearch };
 
 function pushSearch() {
-  var state = {'action': 'search'};
+  var state = {'search': null, 'action': 'search'};
   ['#include', '#exclude', '#equipment'].forEach(function (element) {
     var fragment = element.replace('#', '');
     var data = $(element).val();

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -24,13 +24,15 @@ function pushSearch() {
   var sortChoice = getState().sort;
   if (sortChoice) state['sort'] = sortChoice;
 
+  var stateHash = decodeURIComponent($.param(state));
+  stateHash = stateHash.split('&').map(item => item.replace(RegExp('=$'), '')).join('&');
+
   // If the requested search is a repeat of the current state, perform a results refresh
   // This is done to ensure that the results are scrolled into view
-  var stateHash = decodeURIComponent($.param(state));
   if (window.location.hash === `#${stateHash}`) {
     $('#search table[data-row-attributes]').trigger('page-change.bs.table');
   }
-  pushState(state, `#search&${stateHash}`);
+  pushState(state, `#${stateHash}`);
   $(window).trigger('popstate');
 }
 $('#search form button').on('click', pushSearch);
@@ -115,7 +117,9 @@ function createSortPrompt() {
     delete state.page;
 
     var stateHash = decodeURIComponent($.param(state));
-    pushState(state, `#search&${stateHash}`);
+    stateHash = stateHash.split('&').map(item => item.replace(RegExp('=$'), '')).join('&');
+
+    pushState(state, `#${stateHash}`);
     $(window).trigger('popstate');
   });
 

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -53,9 +53,7 @@ function renderSearch() {
 
 function renderIndividual() {
   var id = getState().id;
-  $('#search table[data-row-attributes]').bootstrapTable('refresh', {
-    url: '/api/recipes/' + encodeURIComponent(id) + '/view'
-  });
+  $('#search form').hide();
 }
 
 function renderRefinement(refinement) {

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -6,8 +6,9 @@ import 'bootstrap-table/dist/bootstrap-table.css';
 import './search.css';
 
 import '../autosuggest';
+import { getRecipeById } from '../common';
 import { i18nAttr, localize } from '../i18n';
-import { getState, pushState } from '../state';
+import { getState, loadPage, pushState } from '../state';
 import { initTable, bindLoadEvent } from './components/recipe-list';
 
 export { renderSearch, renderIndividual };
@@ -53,7 +54,11 @@ function renderSearch() {
 
 function renderIndividual() {
   var id = getState().id;
-  $('#search form').hide();
+  var recipe = getRecipeById(id);
+
+  $('#recipe div.title').text(recipe.title);
+
+  loadPage('recipe');
 }
 
 function renderRefinement(refinement) {

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -6,12 +6,11 @@ import 'bootstrap-table/dist/bootstrap-table.css';
 import './search.css';
 
 import '../autosuggest';
-import { getRecipeById } from '../common';
 import { i18nAttr, localize } from '../i18n';
-import { getState, loadPage, pushState } from '../state';
+import { getState, pushState } from '../state';
 import { initTable, bindLoadEvent } from './components/recipe-list';
 
-export { renderSearch, renderIndividual };
+export { renderSearch };
 
 function pushSearch() {
   var state = {'action': 'search'};
@@ -50,15 +49,6 @@ function renderSearch() {
     url: '/api/recipes/search?' + $.param(params),
     pageNumber: Number(state.page || 1)
   });
-}
-
-function renderIndividual() {
-  var id = getState().id;
-  var recipe = getRecipeById(id);
-
-  $('#recipe div.title').text(recipe.title);
-
-  loadPage('recipe');
 }
 
 function renderRefinement(refinement) {

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -31,7 +31,7 @@ function pushSearch() {
   if (window.location.hash === `#${stateHash}`) {
     $('#search table[data-row-attributes]').trigger('page-change.bs.table');
   }
-  pushState(state, `#${stateHash}`);
+  pushState(state, `#search&${stateHash}`);
   $(window).trigger('popstate');
 }
 $('#search form button').on('click', pushSearch);
@@ -125,7 +125,7 @@ function createSortPrompt() {
     delete state.page;
 
     var stateHash = decodeURIComponent($.param(state));
-    pushState(state, `#${stateHash}`);
+    pushState(state, `#search&${stateHash}`);
     $(window).trigger('popstate');
   });
 

--- a/src/index.html
+++ b/src/index.html
@@ -63,7 +63,7 @@
       </div>
     </header>
 
-    <div id="recipe" class="container collapse">
+    <div id="recipe" class="container collapse recipe">
       <div class="card-deck mb-4 pt-3">
         <div class="card">
           <div class="card-body">

--- a/src/index.html
+++ b/src/index.html
@@ -68,6 +68,7 @@
         <div class="card">
           <div class="card-body">
             <div class="title"></div>
+            <div class="corner"></div>
             <div class="contents">
               <div class="image"></div>
               <div class="metadata"></div>

--- a/src/index.html
+++ b/src/index.html
@@ -70,6 +70,8 @@
             <div class="title"></div>
             <div class="contents">
               <div class="image"></div>
+            </div>
+            <div class="contents">
               <div class="ingredients"></div>
               <div class="directions"></div>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -70,8 +70,6 @@
             <div class="title"></div>
             <div class="contents">
               <div class="image"></div>
-            </div>
-            <div class="contents">
               <div class="ingredients"></div>
               <div class="directions"></div>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -68,6 +68,11 @@
         <div class="card">
           <div class="card-body">
             <div class="title"></div>
+            <div class="contents">
+              <div class="image"></div>
+              <div class="ingredients"></div>
+              <div class="directions"></div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -103,6 +103,7 @@
         <table
           class="tablesaw tablesaw-stack"
           data-tablesaw-mode="stack"
+          data-classes="table"
           data-data-field="results"
           data-total-field="total"
           data-pagination="true"
@@ -126,6 +127,7 @@
         <table
           class="tablesaw tablesaw-stack"
           data-tablesaw-mode="stack"
+          data-classes="table"
           data-pagination="true"
           data-pagination-loop="false"
           data-pagination-v-align="both"

--- a/src/index.html
+++ b/src/index.html
@@ -70,6 +70,7 @@
             <div class="title"></div>
             <div class="contents">
               <div class="image"></div>
+              <div class="metadata"></div>
               <div class="ingredients"></div>
               <div class="directions"></div>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -63,6 +63,16 @@
       </div>
     </header>
 
+    <div id="recipe" class="container collapse">
+      <div class="card-deck mb-4 pt-3">
+        <div class="card">
+          <div class="card-body">
+            <div class="title"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div id="search" class="container">
       <div class="card-deck mb-4 pt-3">
         <form class="card" onsubmit="return false">


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Although the search results pages are useful for scanning through a number of potentially relevant recipes, screen space is limited.

During meal preparation it makes more sense to have a single recipe in view, using the full extent of the screen size.  That way, directions and ingredients can be shown simultaneously and in larger font sizes.

This feature is part of the [RecipeRadar Q2 2020 roadmap](https://github.com/openculinary/company/blob/9c477d0ff01fdfe4b0f5574408eb61494bcf8e5c/roadmap/reciperadar.md).

![image](https://user-images.githubusercontent.com/55152140/84817556-10bb5f80-b00d-11ea-9f29-00050ac495d8.png)

### Briefly summarize the changes
1. Add a 'recipe detail view' page where a single recipe is rendered using the full application viewport
1. Allow users to highlight and tap direction steps to keep track of their progress during meal preparation
1. Provide access to the 'add recipe' and 'star recipe' functions provided in the search results

### How have the changes been tested?
1. Local development testing