### PR TITLE
Bugfix: product 'recipes' field was being overwritten

### DIFF
--- a/src/app/models/products.js
+++ b/src/app/models/products.js
@@ -22,16 +22,15 @@ function aggregateUnitQuantities(product, mealCounts) {
 
 function addProduct(product, recipeId) {
   var products = storage.products.load();
-  if (product.product_id in products) {
-    product.category = products[product.product_id].category;
-  }
   if (!product.state) {
     product.state = 'required';
   }
   if (!product.recipes) {
     product.recipes = {};
   }
-
+  if (product.product_id in products) {
+    product.category = products[product.product_id].category;
+  }
   if (recipeId) {
     if (!(recipeId in product.recipes)) {
       product.recipes[recipeId] = {amounts: []};

--- a/src/app/models/products.js
+++ b/src/app/models/products.js
@@ -30,6 +30,7 @@ function addProduct(product, recipeId) {
   }
   if (product.product_id in products) {
     product.category = products[product.product_id].category;
+    Object.assign(product.recipes, products[product.product_id].recipes);
   }
   if (recipeId) {
     if (!(recipeId in product.recipes)) {


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The `product.recipes` field - as stored in the user's local application state - is a JavaScript object that contains keys for each of the user's planned recipes that refer to the product.  It may be an empty object if the user has manually added a product to their shopping list.

Prior to this change, when a user added a recipe to their meal plan, each product was written to the local storage without first checking for existing `product.recipes` entries.  In other words, each product could only have a maximum of one recipe (the most recently added) referenced.

This change ensures that we merge the existing recipe references into the product before saving it into the local storage.

### Briefly summarize the changes
1. Merge existing `product.recipes` keys before writing to application local storage

### How have the changes been tested?
1. Local development testing