### PR TITLE
Feature: recipe scaling

### DIFF
--- a/src/app/common.js
+++ b/src/app/common.js
@@ -29,8 +29,6 @@ function getRecipeProducts(recipe) {
       singular: ingredient.product.singular,
       plural: ingredient.product.plural,
       state: ingredient.product.state,
-      quantity: ingredient.quantity,
-      units: ingredient.units,
     });
   });
   return recipeProducts;

--- a/src/app/main.css
+++ b/src/app/main.css
@@ -81,6 +81,10 @@ span.tag.required {
   background-color: #f0f0f0;
 }
 
+span.tag.servings {
+  background-color: #b0b0ff;
+}
+
 /* disable pull-down-to-refresh in chrome */
 body {
   overscroll-behavior: contain;

--- a/src/app/models/products.js
+++ b/src/app/models/products.js
@@ -22,25 +22,28 @@ function aggregateUnitQuantities(product, recipeServings) {
   return unitQuantities;
 }
 
-function addProduct(product, recipeId) {
-  var products = storage.products.load();
+function addProduct(ingredient, recipeId) {
+  var product = ingredient.product;
   if (!product.state) {
     product.state = 'required';
   }
   if (!product.recipes) {
     product.recipes = {};
   }
+
+  var products = storage.products.load();
   if (product.product_id in products) {
     product.category = products[product.product_id].category;
     Object.assign(product.recipes, products[product.product_id].recipes);
   }
+
   if (recipeId) {
     if (!(recipeId in product.recipes)) {
       product.recipes[recipeId] = {amounts: []};
     }
     product.recipes[recipeId].amounts.push({
-      quantity: product.quantity,
-      units: product.units
+      quantity: ingredient.quantity,
+      units: ingredient.units
     });
   }
 

--- a/src/app/models/recipes.js
+++ b/src/app/models/recipes.js
@@ -13,8 +13,8 @@ function addRecipe() {
   storage.recipes.add({'hashCode': recipe.id, 'value': recipe});
   updateRecipeState(recipe.id);
 
-  recipe.products.forEach(function (product) {
-    addProduct(product, recipe.id);
+  recipe.ingredients.forEach(function (ingredient) {
+    addProduct(ingredient, recipe.id);
   });
 }
 

--- a/src/app/models/recipes.js
+++ b/src/app/models/recipes.js
@@ -5,7 +5,7 @@ import { storage } from '../storage';
 import { addProduct, removeProduct } from '../models/products';
 import { updateRecipeState } from '../views/components/recipe-list';
 
-export { addRecipe, removeRecipe };
+export { addRecipe, removeRecipe, scaleRecipe };
 
 function addRecipe() {
   var recipe = getRecipe(this);
@@ -31,4 +31,12 @@ function removeRecipe() {
 
   storage.recipes.remove({'hashCode': recipe.id});
   updateRecipeState(recipe.id);
+}
+
+function scaleRecipe(recipe, targetServings) {
+  $.each(recipe.ingredients, function() {
+    this.quantity *= targetServings;
+    this.quantity /= recipe.servings;
+  });
+  recipe.servings = targetServings;
 }

--- a/src/app/models/recipes.js
+++ b/src/app/models/recipes.js
@@ -1,6 +1,7 @@
 import 'jquery';
 
 import { getRecipe } from '../common';
+import { getState } from '../state';
 import { storage } from '../storage';
 import { addProduct, removeProduct } from '../models/products';
 import { updateRecipeState } from '../views/components/recipe-list';
@@ -9,6 +10,9 @@ export { addRecipe, removeRecipe, scaleRecipe };
 
 function addRecipe() {
   var recipe = getRecipe(this);
+
+  var state = getState();
+  if (state.servings) scaleRecipe(recipe, state.servings);
 
   storage.recipes.add({'hashCode': recipe.id, 'value': recipe});
   updateRecipeState(recipe.id);

--- a/src/app/models/recipes.js
+++ b/src/app/models/recipes.js
@@ -12,7 +12,7 @@ function addRecipe() {
   var recipe = getRecipe(this);
 
   var state = getState();
-  if (state.servings) scaleRecipe(recipe, state.servings);
+  if (state.servings) scaleRecipe(recipe, Number(state.servings));
 
   storage.recipes.add({'hashCode': recipe.id, 'value': recipe});
   updateRecipeState(recipe.id);

--- a/src/app/views/meals.css
+++ b/src/app/views/meals.css
@@ -20,6 +20,13 @@
   text-decoration: inherit;
 }
 
+#meal-planner .recipe a.link {
+  color: red;
+  cursor: pointer;
+  font-weight: bold;
+  text-decoration: none;
+  margin-right: 0.5em;
+}
 #meal-planner .recipe a.remove {
   color: red;
   cursor: pointer;

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -64,7 +64,7 @@ function recipeElement(recipe) {
 
   var link = $('<a />', {
     'class': 'remove fa fa-link',
-    'href': `#search&action=view&id=${recipe.id}`
+    'href': `#search&action=view&id=${recipe.id}&servings=${recipe.servings}`
   });
   var item = $('<div />', {'style': 'float: left'});
   item.append(link);

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -41,11 +41,6 @@ function updateHints() {
 }
 
 function recipeElement(recipe) {
-  var link = $('<a />', {
-    'class': 'remove fa fa-link',
-    'href': `#search&action=view&id=${recipe.id}`
-  });
-
   var cloneRemove = $('<span />', {
     'click': removeMeal,
     'data-role': 'remove'
@@ -67,6 +62,10 @@ function recipeElement(recipe) {
   });
   remove.on('click', removeRecipe);
 
+  var link = $('<a />', {
+    'class': 'remove fa fa-link',
+    'href': `#search&action=view&id=${recipe.id}`
+  });
   var item = $('<div />', {
     'style': 'float: left'
   });

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -65,7 +65,7 @@ function recipeElement(recipe) {
   // TODO: only include 'servings' parameter when the value overrides the recipe default
   // This may require some data model refactoring
   var link = $('<a />', {
-    'class': 'remove fa fa-link',
+    'class': 'fa fa-link',
     'href': `#search&action=view&id=${recipe.id}&servings=${recipe.servings}`
   });
   var item = $('<div />', {'style': 'float: left'});

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -62,6 +62,8 @@ function recipeElement(recipe) {
   });
   remove.on('click', removeRecipe);
 
+  // TODO: only include 'servings' parameter when the value overrides the recipe default
+  // This may require some data model refactoring
   var link = $('<a />', {
     'class': 'remove fa fa-link',
     'href': `#search&action=view&id=${recipe.id}&servings=${recipe.servings}`

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -53,6 +53,11 @@ function recipeElement(recipe) {
   });
   title.append(cloneRemove);
 
+  var servings = $('<span />', {
+    'class': 'tag badge servings',
+    'text': recipe.servings
+  });
+
   var remove = $('<a />', {
     'class': 'remove fa fa-trash-alt',
     'style': 'float: right; margin-left: 8px; margin-top: 3px;'
@@ -71,6 +76,7 @@ function recipeElement(recipe) {
     'data-id': recipe.id
   });
   container.append(item);
+  container.append(servings);
   container.append(remove);
 
   return container;

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -41,12 +41,15 @@ function updateHints() {
 }
 
 function recipeElement(recipe) {
-  var link = $('<a />', {'class': 'remove fa fa-link', 'href': `#search&action=view&id=${recipe.id}`});
+  var link = $('<a />', {
+    'class': 'remove fa fa-link',
+    'href': `#search&action=view&id=${recipe.id}`
+  });
+
   var cloneRemove = $('<span />', {
     'click': removeMeal,
     'data-role': 'remove'
   });
-
   var title = $('<span />', {
     'class': 'tag badge badge-info',
     'text': recipe.title

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -65,7 +65,7 @@ function recipeElement(recipe) {
   // TODO: only include 'servings' parameter when the value overrides the recipe default
   // This may require some data model refactoring
   var link = $('<a />', {
-    'class': 'fa fa-link',
+    'class': 'link fa fa-link',
     'href': `#search&action=view&id=${recipe.id}&servings=${recipe.servings}`
   });
   var item = $('<div />', {'style': 'float: left'});

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -66,9 +66,7 @@ function recipeElement(recipe) {
     'class': 'remove fa fa-link',
     'href': `#search&action=view&id=${recipe.id}`
   });
-  var item = $('<div />', {
-    'style': 'float: left'
-  });
+  var item = $('<div />', {'style': 'float: left'});
   item.append(link);
   item.append(title);
 

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -71,6 +71,10 @@
   grid-column: 2;
 }
 
+#recipe div.contents div.metadata input.servings {
+  width: 4rem;
+}
+
 #recipe div.contents div.section-title {
   font-weight: bold;
   color: #006;

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -55,9 +55,12 @@ function updateStarState() {
 }
 
 function renderRecipe() {
-  var id = getState().id;
+  var state = getState();
+
+  var id = state.id;
   var recipe = getRecipeById(id);
   var duration = moment.duration(recipe.time, 'minutes');
+  var targetServings = state.servings || recipe.servings;
 
   var container = $('#recipe');
   var title = $('#recipe div.title').empty();

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -129,7 +129,9 @@ function renderRecipe() {
 }
 
 function renderIngredients(servings) {
-  var ingredients = $('#recipe div.ingredients').empty();
+  var existingIngredients = $('#recipe div.ingredients');
+
+  var ingredients = $('<div />', {'class': 'ingredients'});
   ingredients.append($('<div />', {
     'class': 'headline section-title',
     'data-i18n': i18nAttr('search:result-tab-ingredients')
@@ -154,4 +156,6 @@ function renderIngredients(servings) {
   ingredients.append(addButton);
 
   localize('#recipe .ingredients');
+
+  existingIngredients.replaceWith(ingredients);
 }

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -62,7 +62,7 @@ function renderRecipe() {
   var recipe = getRecipe(container);
   var duration = moment.duration(recipe.time, 'minutes');
 
-  var targetServings = state.servings || recipe.servings;
+  var targetServings = Number(state.servings) || recipe.servings;
   scaleRecipe(recipe, targetServings);
 
   var title = $('#recipe div.title').empty();

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -100,6 +100,7 @@ function renderRecipe() {
     'text': 'Add to shopping list'
   });
   addButton.on('click', addRecipe);
+  addButton.on('click', updateRecipeState);
 
   ingredients.append(addButton);
 
@@ -121,9 +122,6 @@ function renderRecipe() {
   localize('#recipe');
   loadPage('recipe');
 
+  updateRecipeState();
   updateStarState();
 }
-
-$(function() {
-  storage.recipes.on('state changed', updateRecipeState);
-});

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -155,7 +155,7 @@ function renderIngredients(servings) {
 
   ingredients.append(addButton);
 
-  localize('#recipe .ingredients');
-
   existingIngredients.replaceWith(ingredients);
+
+  localize('#recipe .ingredients');
 }

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -7,7 +7,7 @@ import { i18nAttr, localize } from '../i18n';
 import { addRecipe, scaleRecipe } from '../models/recipes';
 import { starRecipe, unstarRecipe } from '../models/starred';
 import { renderIngredientHTML, renderDirectionHTML } from '../recipeml';
-import { getState, loadPage } from '../state';
+import { getState, loadPage, pushState, renderStateHash } from '../state';
 import { storage } from '../storage';
 
 export { renderRecipe };
@@ -54,6 +54,15 @@ function updateStarState() {
   star.on('click', updateStarState);
 }
 
+function updateServings() {
+  var state = getState();
+  state.servings = $('#recipe div.metadata input.servings').val();
+
+  var stateHash = renderStateHash(state);
+  pushState(state, stateHash);
+  $(window).trigger('popstate');
+}
+
 function renderRecipe() {
   var state = getState();
   var container = $('#recipe');
@@ -80,8 +89,18 @@ function renderRecipe() {
   corner.append(starFormatter());
   image.append(link);
 
+  var servingsInput = $('<input>', {
+    'class': 'servings',
+    'min': 1,
+    'max': 50,
+    'type': 'number',
+  });
+  servingsInput.attr('aria-label', 'Serving count selection');
+  servingsInput.val(recipe.servings);
+  servingsInput.on('change', updateServings);
+
   metadata.append($('<div />', {'class': 'property', 'text': 'servings'}));
-  metadata.append($('<div />', {'class': 'value', 'text': recipe.servings}));
+  metadata.append($('<div />', {'class': 'value'}).append(servingsInput));
   metadata.append($('<div />', {'class': 'property', 'text': 'time'}));
   metadata.append($('<div />', {'class': 'value', 'text': duration.as('minutes') + ' mins'}));
 

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -4,7 +4,7 @@ import './recipe.css';
 
 import { getRecipe } from '../common';
 import { i18nAttr, localize } from '../i18n';
-import { addRecipe } from '../models/recipes';
+import { addRecipe, scaleRecipe } from '../models/recipes';
 import { starRecipe, unstarRecipe } from '../models/starred';
 import { renderIngredientHTML, renderDirectionHTML } from '../recipeml';
 import { getState, loadPage } from '../state';
@@ -61,7 +61,9 @@ function renderRecipe() {
 
   var recipe = getRecipe(container);
   var duration = moment.duration(recipe.time, 'minutes');
+
   var targetServings = state.servings || recipe.servings;
+  scaleRecipe(recipe, targetServings);
 
   var title = $('#recipe div.title').empty();
   var corner = $('#recipe div.corner').empty();
@@ -89,8 +91,6 @@ function renderRecipe() {
   }));
 
   $.each(recipe.ingredients, function() {
-    this.quantity *= targetServings;
-    this.quantity /= recipe.servings;
     ingredients.append(renderIngredientHTML(this));
   });
 

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -152,4 +152,6 @@ function renderIngredients(servings) {
   addButton.on('click', updateRecipeState);
 
   ingredients.append(addButton);
+
+  localize('#recipe .ingredients');
 }

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -2,7 +2,7 @@ import * as moment from 'moment';
 
 import './recipe.css';
 
-import { getRecipeById } from '../common';
+import { getRecipe } from '../common';
 import { i18nAttr, localize } from '../i18n';
 import { addRecipe } from '../models/recipes';
 import { starRecipe, unstarRecipe } from '../models/starred';
@@ -56,13 +56,13 @@ function updateStarState() {
 
 function renderRecipe() {
   var state = getState();
+  var container = $('#recipe');
+  container.data('id', state.id);
 
-  var id = state.id;
-  var recipe = getRecipeById(id);
+  var recipe = getRecipe(container);
   var duration = moment.duration(recipe.time, 'minutes');
   var targetServings = state.servings || recipe.servings;
 
-  var container = $('#recipe');
   var title = $('#recipe div.title').empty();
   var corner = $('#recipe div.corner').empty();
   var image = $('#recipe div.image').empty();

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -55,12 +55,15 @@ function updateStarState() {
 }
 
 function updateServings() {
+  var targetServings = $('#recipe div.metadata input.servings').val();
+
   var state = getState();
-  state.servings = $('#recipe div.metadata input.servings').val();
+  state.servings = targetServings;
 
   var stateHash = renderStateHash(state);
   pushState(state, stateHash);
-  $(window).trigger('popstate');
+
+  renderIngredients(targetServings);
 }
 
 function renderRecipe() {
@@ -71,14 +74,10 @@ function renderRecipe() {
   var recipe = getRecipe(container);
   var duration = moment.duration(recipe.time, 'minutes');
 
-  var targetServings = Number(state.servings) || recipe.servings;
-  scaleRecipe(recipe, targetServings);
-
   var title = $('#recipe div.title').empty();
   var corner = $('#recipe div.corner').empty();
   var image = $('#recipe div.image').empty();
   var metadata = $('#recipe div.metadata').empty();
-  var ingredients = $('#recipe div.ingredients').empty();
   var directions = $('#recipe div.directions').empty();
 
   var link = $('<a />', {'href': recipe.dst});
@@ -89,6 +88,7 @@ function renderRecipe() {
   corner.append(starFormatter());
   image.append(link);
 
+  var targetServings = Number(state.servings) || recipe.servings;
   var servingsInput = $('<input>', {
     'class': 'servings',
     'min': 1,
@@ -96,7 +96,7 @@ function renderRecipe() {
     'type': 'number',
   });
   servingsInput.attr('aria-label', 'Serving count selection');
-  servingsInput.val(recipe.servings);
+  servingsInput.val(targetServings);
   servingsInput.on('change', updateServings);
 
   metadata.append($('<div />', {'class': 'property', 'text': 'servings'}));
@@ -104,24 +104,7 @@ function renderRecipe() {
   metadata.append($('<div />', {'class': 'property', 'text': 'time'}));
   metadata.append($('<div />', {'class': 'value', 'text': duration.as('minutes') + ' mins'}));
 
-  ingredients.append($('<div />', {
-    'class': 'headline section-title',
-    'data-i18n': i18nAttr('search:result-tab-ingredients')
-  }));
-
-  $.each(recipe.ingredients, function() {
-    ingredients.append(renderIngredientHTML(this));
-  });
-
-  // TODO: i18n
-  var addButton = $('<button />', {
-    'class': 'headline btn btn-outline-primary add-recipe',
-    'text': 'Add to shopping list'
-  });
-  addButton.on('click', addRecipe);
-  addButton.on('click', updateRecipeState);
-
-  ingredients.append(addButton);
+  renderIngredients(targetServings);
 
   directions.append($('<div />', {
     'class': 'section-title',
@@ -143,4 +126,30 @@ function renderRecipe() {
 
   updateRecipeState();
   updateStarState();
+}
+
+function renderIngredients(servings) {
+  var ingredients = $('#recipe div.ingredients').empty();
+  ingredients.append($('<div />', {
+    'class': 'headline section-title',
+    'data-i18n': i18nAttr('search:result-tab-ingredients')
+  }));
+
+  var container = $('#recipe');
+  var recipe = getRecipe(container);
+  scaleRecipe(recipe, servings);
+
+  $.each(recipe.ingredients, function() {
+    ingredients.append(renderIngredientHTML(this));
+  });
+
+  // TODO: i18n
+  var addButton = $('<button />', {
+    'class': 'headline btn btn-outline-primary add-recipe',
+    'text': 'Add to shopping list'
+  });
+  addButton.on('click', addRecipe);
+  addButton.on('click', updateRecipeState);
+
+  ingredients.append(addButton);
 }

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -89,6 +89,8 @@ function renderRecipe() {
   }));
 
   $.each(recipe.ingredients, function() {
+    this.quantity *= targetServings;
+    this.quantity /= recipe.servings;
     ingredients.append(renderIngredientHTML(this));
   });
 

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -165,7 +165,8 @@ function bindShoppingListInput(element, placeholder) {
     var product = event.params.data.product;
     if (product.product_id in products) return;
 
-    addProduct(product);
+    var ingredient = {product: product};
+    addProduct(ingredient);
   });
 }
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Although recipes may specify a number of servings or yield size, in practice it's frequently useful to adjust ingredient quantities  to produce a meal of a smaller or larger size.  For example, a recipe might specify that it produces two servings, and then someone may wish to prepare a meal using that recipe for themselves and three friends.

This changeset takes a naive initial approach towards recipe scaling; the user can specify the number of servings they'd like for a given recipe, and based on that 'target' serving size, a simple numeric ratio is applied to each ingredient's quantity.

This will not work perfectly for all recipes in practice -- it's not possible, for example, to purchase or use 1.5 eggs.  Therefore in future it'll make sense to incorporate more intelligent scaling logic that may depend on the properties of different types of ingredient.

### Briefly summarize the changes
1. Add a user-specified `servings` variable to the recipe-detail page query string
2. Apply ratio-based scaling to recipe ingredient quantities
3. Carry the selected target `servings` value into the user's meal planner when they add recipes
4. Display the number of servings alongside each recipe entry in the meal planner

### How have the changes been tested?
1. Unit test coverage should be provided along with this changeset

**List any issues that this change relates to**
Resolves #2 