### PR TITLE
Cleanup: require explicit imports for jQuery usage

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -6,3 +6,6 @@ global.XMLHttpRequest = xmlhttprequest.XMLHttpRequest;
 global.document = dom.document;
 global.window = dom.window;
 global.self = dom.window;
+
+const jquery = require('jquery');
+window.$ = jquery;

--- a/src/app/autosuggest.js
+++ b/src/app/autosuggest.js
@@ -1,4 +1,4 @@
-import 'jquery';
+import $ from 'jquery';
 import 'select2';
 
 function bindEquipmentInput(element, label, placeholder) {

--- a/src/app/common.js
+++ b/src/app/common.js
@@ -1,4 +1,4 @@
-import 'jquery';
+import $ from 'jquery';
 
 import { db } from './database';
 

--- a/src/app/dialogs/about.js
+++ b/src/app/dialogs/about.js
@@ -1,6 +1,6 @@
-import 'bootstrap';
-import 'jquery';
+import $ from 'jquery';
 import * as d3 from 'd3';
+import 'bootstrap';
 import { sankey as sankeyInstance, sankeyVertical } from 'd3-sankey';
 
 import data from './about-diagram.json';

--- a/src/app/i18n.js
+++ b/src/app/i18n.js
@@ -1,4 +1,4 @@
-import 'jquery';
+import $ from 'jquery';
 import jqueryi18next from 'jquery-i18next';
 
 import i18next from 'i18next';

--- a/src/app/models/recipes.js
+++ b/src/app/models/recipes.js
@@ -1,4 +1,4 @@
-import 'jquery';
+import $ from 'jquery';
 
 import { db } from '../database';
 import { addProduct } from '../models/products';

--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -1,3 +1,5 @@
+import $ from 'jquery';
+
 import { renderQuantity } from './conversion';
 
 export { renderIngredientHTML, renderDirectionHTML };

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -1,4 +1,4 @@
-import 'jquery';
+import $ from 'jquery';
 
 import { renderRecipe } from './views/recipe';
 import { renderSearch } from './views/search';

--- a/src/app/views/components/recipe-list.js
+++ b/src/app/views/components/recipe-list.js
@@ -1,4 +1,4 @@
-import 'jquery';
+import $ from 'jquery';
 import * as moment from 'moment';
 import 'tablesaw/dist/stackonly/tablesaw.stackonly.jquery.js';
 

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -1,4 +1,4 @@
-import 'jquery';
+import $ from 'jquery';
 import * as moment from 'moment';
 import { Sortable } from 'sortablejs';
 import i18next from 'i18next';

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import * as moment from 'moment';
 
 import { getRecipe, getRecipeById } from '../common';

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -1,4 +1,4 @@
-import 'jquery';
+import $ from 'jquery';
 import 'bootstrap-table';
 
 import '../autosuggest';

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -1,4 +1,4 @@
-import 'jquery';
+import $ from 'jquery';
 import 'select2';
 
 import { renderQuantity } from '../conversion';

--- a/src/app/views/starred.js
+++ b/src/app/views/starred.js
@@ -1,4 +1,4 @@
-import 'jquery';
+import $ from 'jquery';
 
 import { getRecipeById } from '../common';
 import { db } from '../database';

--- a/src/feedback/feedback.js
+++ b/src/feedback/feedback.js
@@ -134,6 +134,8 @@ i18n.ru_RU = {
 };
 i18n.ru = i18n.ru_RU;
 
+import $ from 'jquery';
+
 var loader = function() {
     var div = $('<div />', {'class': 'feedback-loader'});
     [1, 2, 3].forEach(function() { $('<span />').appendTo(div); });

--- a/src/feedback/loader.js
+++ b/src/feedback/loader.js
@@ -1,4 +1,4 @@
-import 'jquery';
+import $ from 'jquery';
 
 import { Feedback } from './feedback';
 import './feedback.css';

--- a/src/sw/loader.js
+++ b/src/sw/loader.js
@@ -1,6 +1,6 @@
 import { Workbox } from 'workbox-window';
 
-$(function() {
+window.addEventListener('DOMContentLoaded', () => {
   if ('serviceWorker' in navigator) {
     const wb = new Workbox('sw.js');
     wb.addEventListener('waiting', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,11 +73,6 @@ module.exports = (_, env) => {
         filename: '[name].[chunkhash].css'
       }),
       new OptimizeCSSAssetsPlugin(),
-      new webpack.ProvidePlugin({
-        '$': 'jquery',
-        'jQuery': 'jquery',
-        'window.jQuery': 'jquery'
-      }),
       new InjectManifest({
         dontCacheBustURLsMatching: /.*/,
         exclude: ['vendors'],


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The application's webpack configuration had been using the [`ProvidePlugin`](https://webpack.js.org/plugins/provide-plugin/) to make jQuery accessible throughout all component webpack modules.

This is a bit lazy and in the case of the service-worker it partially hid the fact that we did not really require jQuery as a dependency at all.

It may also be possible to remove jQuery from the feedback functionality in the application, and that could lead to further application size savings in future.

### Briefly summarize the changes
1. Make all jQuery usage explicit within application modules
1. Provide jQuery via the `mocha` `setup.js` file, for unit testing environments
1. Remove global provision of jQuery via the `ProvidePlugin`

### How have the changes been tested?
1. Local development testing
1. Existing unit tests continue to pass