### PR TITLE
Fixup: retain recipe removal link action during meal planner drag & drop

### DIFF
--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -129,6 +129,10 @@ function renderMeals() {
 function dragMeal(evt) {
   var elements = [evt.item, evt.clone];
   elements.forEach(function (element) {
+    var recipeRemove = $(element).find('a.remove');
+    recipeRemove.off('click');
+    recipeRemove.on('click', () => { removeRecipe(recipeRemove); });
+
     var mealRemove = $(element).find('span[data-role="remove"]');
     mealRemove.off('click');
     mealRemove.on('click', removeMeal);

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -131,7 +131,7 @@ function dragMeal(evt) {
   elements.forEach(function (element) {
     var recipeRemove = $(element).find('a.remove');
     recipeRemove.off('click');
-    recipeRemove.on('click', () => { removeRecipe(recipeRemove); });
+    recipeRemove.on('click', () => { getRecipe(recipeRemove).then(removeRecipe).then(updateRecipeState) });
 
     var mealRemove = $(element).find('span[data-role="remove"]');
     mealRemove.off('click');


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
During #154, some apparently redundant code related to meal planner drag-and-drop was [removed](https://github.com/openculinary/frontend/pull/154/commits/b04c472adc63559cc9d28b4e2aa46c6389363745).

This code creates a new 'remove recipe' link and it was assumed that this was not required since items dropped onto the calendar do not include the 'trash can' (remove recipe completely from planner) icon.

However it turns out that this step is still required.  This changeset ensures that both the original recipe name and the cloned recipe name have a 'remove recipe' link rendered alongside.  This icon is later hidden by CSS rules for elements inside the meal calendar. 

### Briefly summarize the changes
1. Revert the offending change
1. Bring the recipe removal code in-line with changes made in the meantime

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Fixes #157.