### PR TITLE
Ensure that recipe.servings is stored as a numeric value

### DIFF
--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -121,7 +121,7 @@ function renderIngredients(recipe) {
     'data-i18n': i18nAttr('search:result-tab-ingredients')
   }));
 
-  var servings = getState().servings || recipe.servings;
+  var servings = Number(getState().servings) || recipe.servings;
   scaleRecipe(recipe, servings);
 
   $.each(recipe.ingredients, function() {


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Previously, the `servings` value read from the current application state would have been stored as a string value on the recipe object, not a numeric value as intended.

This had the potential to cause problems in mathematical operations using the `recipe.servings` field; in JavaScript, adding two strings concatenates them, and multiplying a number by a string will perform an implicit cast of the string to a numeric value.

### Briefly summarize the changes
1. Ensure that the `servings` value retrieved from the application state is cast to a numeric value

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Fixes #159 