### PR TITLE
Service Worker: remove use of workbox-core.skipWaiting

### DIFF
--- a/src/sw/sw.js
+++ b/src/sw/sw.js
@@ -1,11 +1,10 @@
-import { skipWaiting } from 'workbox-core';
 import { precacheAndRoute } from 'workbox-precaching';
 import { registerRoute } from 'workbox-routing';
 import { NetworkFirst } from 'workbox-strategies';
 
 addEventListener('message', (event) => {
   if (event.data && event.data.type == 'skipWaiting') {
-    skipWaiting();
+    self.skipWaiting();
   }
 });
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
As reported in #165, updates to the application's service worker do not appear to have been applying correctly.

The root cause of this appears to be https://github.com/GoogleChrome/workbox/issues/2525 - the [`workbox-core.skipWaiting`](https://github.com/GoogleChrome/workbox/blob/fe4399505e02c3af6515fc8ffae8c58791f43f3c/packages/workbox-core/src/skipWaiting.ts#L25) function which registers an `install`-time event handler.

I think what's been happening is that the application's newly-retrieved service worker has already reached the `install` state by the time it receives a `skipWaiting` message from the application.  That means that the `workbox-core` event handler doesn't fire, and the worker remains in a waiting state indefinitely.

### Briefly summarize the changes
1. Call `skipWaiting` directly on the service worker since we are not concerned about install timing for the worker

### How have the changes been tested?
1. Local development testing
1. User-verified

**List any issues that this change relates to**
Fixes #165 
