### PR TITLE
Support rendering for 'action' elements in recipe direction markup

### DIFF
--- a/src/app/recipeml.js
+++ b/src/app/recipeml.js
@@ -23,7 +23,8 @@ function renderDirectionHTML(direction) {
     const xml = $.parseXML(`<xml>${direction.markup}</xml>`).firstChild;
     const container = $('<div />');
 
-    $(xml).find('mark').replaceWith((idx, text) => $('<span />', {'class': 'equipment tag badge', 'text': text}));
+    $(xml).find('mark[class*=equipment]').replaceWith((idx, text) => $('<span />', {'class': 'equipment tag badge', 'text': text}));
+    $(xml).find('mark[class*=action]').replaceWith((idx, text) => $('<span />', {'class': 'action', 'text': text}));
     const directionHTML = $('<li />', {'class': 'direction', 'html': xml.childNodes});
 
     container.append(directionHTML);

--- a/test/recipeml.js
+++ b/test/recipeml.js
@@ -82,8 +82,18 @@ describe('html rendering', function() {
   });
 
   it('renders simple direction', function() {
-    var recipeML = 'place the <mark>casserole dish</mark> in the <mark>oven</mark>';
+    var recipeML = 'place the <mark class="equipment vessel">casserole dish</mark> in the <mark class="equipment appliance">oven</mark>';
     var expected = '<li class="direction">place the <span class="equipment tag badge">casserole dish</span> in the <span class="equipment tag badge">oven</span></li>';
+
+    var direction = directionHelper(recipeML);
+    var rendered = renderDirectionHTML(direction);
+
+    assert.equal(expected, rendered);
+  });
+
+  it('renders directions with actions and equipment', function() {
+    var recipeML = '<mark class="action">heat</mark> the <mark class="equipment appliance">oven</mark> to 200 F';
+    var expected = '<li class="direction"><span class="action">heat</span> the <span class="equipment tag badge">oven</span> to 200 F</li>';
 
     var direction = directionHelper(recipeML);
     var rendered = renderDirectionHTML(direction);


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Since merging openculinary/knowledge-graph#47, we now support tagging of `actions` (for now, simply words that are verbs) within recipe direction markup.

This changeset adds rendering support for these to the frontend of the application.

### Briefly summarize the changes
1. Support rendering for `actions` (`<mark class="action">...</mark>`) in recipe direction markup

### How have the changes been tested?
1. Unit test coverage is provided

**List any issues that this change relates to**
Relates to openculinary/knowledge-graph#47