### PR TITLE
Render recipe author attribution when present

### DIFF
--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -3,8 +3,8 @@
   font-size: 24px;
   color: #006;
 
-  padding-top: 1em;
-  padding-left: 2em;
+  padding-top: 20px;
+  padding-left: 50px;
 }
 
 #recipe div.attribution {
@@ -12,8 +12,8 @@
   font-size: 14px;
   color: #006;
 
-  padding-top: 1em;
-  padding-left: 2em;
+  padding-top: 20px;
+  padding-left: 50px;
 }
 
 #recipe .star {
@@ -22,9 +22,9 @@
   font-size: 24px;
   line-height: inherit;
 
-  padding-top: 1em;
-  padding-left: 1em;
-  padding-right: 2em;
+  padding-top: 20px;
+  padding-left: 20px;
+  padding-right: 50px;
 }
 
 #recipe div.contents {

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -7,6 +7,15 @@
   padding-left: 2em;
 }
 
+#recipe div.attribution {
+  font-style: italic;
+  font-size: 14px;
+  color: #006;
+
+  padding-top: 1em;
+  padding-left: 2em;
+}
+
 #recipe .star {
   float: right;
 

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -74,6 +74,7 @@ function renderRecipe() {
     var duration = moment.duration(recipe.time, 'minutes');
 
     var title = $('#recipe div.title').empty();
+    var attribution = $('#recipe div.attribution').empty();
     var corner = $('#recipe div.corner').empty();
     var image = $('#recipe div.image').empty();
     var metadata = $('#recipe div.metadata').empty();
@@ -81,6 +82,13 @@ function renderRecipe() {
     var link = $('<a />', {'href': recipe.dst});
     var img = $('<img />', {'src': recipe.image_url, 'alt': recipe.title});
     link.append(img);
+
+    if (recipe.author) {
+      var author = document.createTextNode(recipe.author);
+      if (recipe.author_url) author = $('<a />', {'href': recipe.author_url}).append(author);
+      attribution.append(document.createTextNode('by '));
+      attribution.append(author);
+    }
 
     container.data('id', recipe.id);
     title.text(recipe.title);

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -84,8 +84,7 @@ function renderRecipe() {
     link.append(img);
 
     if (recipe.author) {
-      var author = document.createTextNode(recipe.author);
-      if (recipe.author_url) author = $('<a />', {'href': recipe.author_url}).append(author);
+      var author = $('<a />', {'href': recipe.author_url || recipe.dst, 'text': recipe.author});
       attribution.append(document.createTextNode('by '));
       attribution.append(author);
     }

--- a/src/index.html
+++ b/src/index.html
@@ -70,6 +70,7 @@
             <div>
               <div class="corner"></div>
               <div class="title"></div>
+              <div class="attribution"></div>
             </div>
             <div class="contents">
               <div class="image"></div>


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Supports recipe author attribution by rendering the name of the author and a link to their recipe -- or profile URL if known -- below each recipe title.

### Briefly summarize the changes
1. Add a recipe attribution line beneath the recipe title

**List any issues that this change relates to**
Relates to openculinary/api#82.
Relates to openculinary/backend#28.
