### PR TITLE
Update product entity field names

### DIFF
--- a/src/app/autosuggest.js
+++ b/src/app/autosuggest.js
@@ -31,7 +31,7 @@ function bindIngredientInput(element, label, placeholder) {
       processResults: data => ({
         results: data.map(item => ({
           id: item.singular,
-          text: item.product,
+          text: item.name,
           product: item
         }))
       })

--- a/src/app/models/products.js
+++ b/src/app/models/products.js
@@ -6,12 +6,12 @@ function addProduct(ingredient, recipeId, index) {
   var product = ingredient.product;
   db.transaction('rw', db.products, db.ingredients, () => {
     db.products.put({
-      id: product.product_id,
+      id: product.id,
       ...product
     });
     db.ingredients.add({
       recipe_id: recipeId,
-      product_id: product.product_id,
+      product_id: product.id,
       index: index,
       ...ingredient
     });

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -30,7 +30,7 @@ function renderProduct(product, ingredients) {
     var tail = `${quantity.magnitude || ''} ${quantity.units || ''}`.trim();
     if (tail.length) text += text.length ? ` + ${tail}` : tail;
   });
-  text += ' ' + product.product;
+  text += ' ' + product.name;
   return text;
 }
 
@@ -174,7 +174,7 @@ function bindShoppingListInput(element, placeholder) {
       data: params => ({pre: params.term}),
       processResults: data => ({
         results: data.map(item => ({
-          id: item.product_id,
+          id: item.id,
           text: item.product,
           product: item
         }))
@@ -190,7 +190,7 @@ function bindShoppingListInput(element, placeholder) {
     var product = event.params.data.product;
     db.ingredients
       .where("product_id")
-      .equals(product.product_id)
+      .equals(product.id)
       .count(count => { if (count === 0) addStandaloneIngredient(product); });
   });
 }

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -175,7 +175,7 @@ function bindShoppingListInput(element, placeholder) {
       processResults: data => ({
         results: data.map(item => ({
           id: item.id,
-          text: item.product,
+          text: item.name,
           product: item
         }))
       })


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This changeset mirrors openculinary/api#92 and renames some product-related field names.

### Briefly summarize the changes
- `product.product_id` is renamed to `product.id` (rationale: the `product_` prefix is implied)
- `product.product` is renamed to `product.name` (rationale: the duplication of the term `product` is confusing)

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Resolves #178.