### PR TITLE
Add current-page link icon to the recipe detail page

### DIFF
--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -16,15 +16,22 @@
   padding-left: 50px;
 }
 
-#recipe .star {
+#recipe div.corner {
   float: right;
 
   font-size: 24px;
-  line-height: inherit;
 
   padding-top: 20px;
-  padding-left: 20px;
   padding-right: 50px;
+}
+
+#recipe div.corner .link,
+#recipe div.corner .star {
+  margin-left: 8px;
+}
+
+#recipe div.corner a.link:hover {
+  text-decoration: none;
 }
 
 #recipe div.contents {

--- a/src/app/views/recipe.css
+++ b/src/app/views/recipe.css
@@ -30,6 +30,9 @@
   margin-left: 8px;
 }
 
+#recipe div.corner a.link {
+  color: gray;
+}
 #recipe div.corner a.link:hover {
   text-decoration: none;
 }

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -24,6 +24,13 @@ function markDirection() {
   $(this).addClass('mark');
 }
 
+function linkFormatter(recipe) {
+  return $('<a />', {
+    'class': 'link fa fa-link',
+    'href': `#search&action=view&id=${recipe.id}`
+  });
+}
+
 function starFormatter() {
   return $('<div />', {'class': 'star far fa-star'});
 }
@@ -91,6 +98,7 @@ function renderRecipe() {
 
     container.data('id', recipe.id);
     title.text(recipe.title);
+    corner.append(linkFormatter(recipe));
     corner.append(starFormatter());
     image.append(link);
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This change adds a hyperlink icon to the recipe detail page, allowing users to share the current recipe URL if they do not have access to an address bar (such as when the application is installed as a PWA).

### Briefly summarize the changes
1. Add a link icon with a URL pointing to the current recipe on the recipe detail page

### How have the changes been tested?
1. Local development testing

### Related issues
Resolves #176.