### PR TITLE
Code re-use: use fraction.js to provide conversion of decimal numbers to fractional representations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "debounce": "^1.2.0",
         "dexie": "^3.0.3",
         "dexie-observable": "^3.0.0-beta.10",
+        "fraction.js": "^4.0.13",
         "html2canvas": "^1.0.0-rc.7",
         "i18next": "^19.8.4",
         "i18next-browser-languagedetector": "^6.0.1",
@@ -6015,6 +6016,14 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.13.tgz",
+      "integrity": "sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/fragment-cache": {
@@ -20721,6 +20730,11 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "fraction.js": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.13.tgz",
+      "integrity": "sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA=="
     },
     "fragment-cache": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "debounce": "^1.2.0",
     "dexie": "^3.0.3",
     "dexie-observable": "^3.0.0-beta.10",
+    "fraction.js": "^4.0.13",
     "html2canvas": "^1.0.0-rc.7",
     "i18next": "^19.8.4",
     "i18next-browser-languagedetector": "^6.0.1",

--- a/src/app/common.js
+++ b/src/app/common.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 
 import { db } from './database';
 
-export { float2rat, getRecipe, getRecipeById };
+export { getRecipe, getRecipeById };
 
 async function getRecipeById(recipeId) {
   return await db.recipes.get(recipeId, async (recipe) => {
@@ -26,25 +26,4 @@ async function getRecipe(el) {
   }
   recipe.mealId = target.data('meal-id');
   return recipe;
-}
-
-// Source: https://stackoverflow.com/a/14357170
-function float2rat(x) {
-    var tolerance = 0.1;
-    var h1=1; var h2=0;
-    var k1=0; var k2=1;
-    var b = x;
-    do {
-        var a = Math.floor(b);
-        var aux = h1; h1 = a*h1+h2; h2 = aux;
-        aux = k1; k1 = a*k1+k2; k2 = aux;
-        b = 1/(b-a);
-    } while (Math.abs(x-h1/k1) > x*tolerance);
-
-    if (k1 === 1) return `${h1}`;
-    if (h1 > k1) {
-        h1 = Math.floor(h1 / k1);
-        return `${h1} 1/${k1}`;
-    }
-    return `${h1}/${k1}`;
 }

--- a/src/app/conversion.js
+++ b/src/app/conversion.js
@@ -1,6 +1,5 @@
 import * as convert from 'convert-units';
-
-import { float2rat } from './common';
+import * as Fraction from 'fraction.js';
 
 export { renderQuantity };
 
@@ -54,7 +53,7 @@ function renderMagnitude(units, magnitude, fractions = true) {
   if (!fractions) {
     return magnitude;
   }
-  var result = float2rat(magnitude);
+  var result = new Fraction(magnitude).simplify(0.1).toFraction(true);
   if (result.indexOf('/') == -1) {
     return result;
   }


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Using existing code libraries and modules that are shared across other codebases and environments is generally a good idea since it creates a common incentive to identify all kinds of performance, security and simplicity improvements within the common library.  It also allows fixes to be applied centrally which then then take effect across multiple environments.

### Briefly summarize the changes
1. Use the [`fraction.js`](https://www.npmjs.com/package/fraction.js) library to perform conversion of decimals to fractions, replacing a code snippet copied from the web (which has been useful, but risks falling out-of-date)

### How have the changes been tested?
1. Unit test coverage continues to pass