### PR TITLE
Migration: use NPM namespace-scoped @openculinary/i18next-gettext-loader package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1179,6 +1179,60 @@
         "rimraf": "^2.7.1"
       }
     },
+    "@openculinary/i18next-gettext-loader": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@openculinary/i18next-gettext-loader/-/i18next-gettext-loader-1.0.1.tgz",
+      "integrity": "sha512-uEsW39t+2OAnZLMFu27zyvPY5Dvi24OiaqV8a5OdKNYIhEZ1jZW8U1Xq/rRLamM6eW868DG2+zcsm30BUxuOBg==",
+      "dev": true,
+      "requires": {
+        "i18next-conv": "^9.2.0"
+      },
+      "dependencies": {
+        "gettext-parser": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-3.1.1.tgz",
+          "integrity": "sha512-vNhWcqXEtZPs5Ft1ReA34g7ByWotpcOIeJvXVy2jF3/G2U9v6W0wG4Z4hXzcU8R//jArqkgHcVCGgGqa4vxVlQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.12",
+            "readable-stream": "^3.2.0",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "i18next-conv": {
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/i18next-conv/-/i18next-conv-9.2.1.tgz",
+          "integrity": "sha512-RAlQIIf5BFfEywqd/1R9W4S3bGL+6qMKD/HKfnSisw9K5tSx4chQKf6pbBNzMyaoTBqWy+ZHS27ZmxE5GIGgag==",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.3",
+            "chalk": "^2.4.2",
+            "commander": "^2.19.0",
+            "gettext-parser": "^3.1.0",
+            "mkdirp": "^0.5.1",
+            "node-gettext": "^2.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "node-gettext": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-2.1.0.tgz",
+          "integrity": "sha512-vsHImHl+Py0vB7M2UXcFEJ5NJ3950gcja45YclBFtYxYeZiqdfQdcu+G9s4L7jpRFSh/J/7VoS3upR4JM1nS+g==",
+          "dev": true,
+          "requires": {
+            "lodash.get": "^4.4.2"
+          }
+        }
+      }
+    },
     "@rollup/plugin-babel": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.2.tgz",
@@ -5772,60 +5826,6 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "i18next-gettext-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/i18next-gettext-loader/-/i18next-gettext-loader-1.0.0.tgz",
-      "integrity": "sha512-uCXmqtwDok4OU3LnImnq6p0HEk4PmQkJdwRUqUtjz00dSP6rUUTMm+xYm1UIhR6h9cWgz5Kb5tsVDqkT64H9xA==",
-      "dev": true,
-      "requires": {
-        "i18next-conv": "^9.2.0"
-      },
-      "dependencies": {
-        "gettext-parser": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-3.1.1.tgz",
-          "integrity": "sha512-vNhWcqXEtZPs5Ft1ReA34g7ByWotpcOIeJvXVy2jF3/G2U9v6W0wG4Z4hXzcU8R//jArqkgHcVCGgGqa4vxVlQ==",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.12",
-            "readable-stream": "^3.2.0",
-            "safe-buffer": "^5.1.2"
-          }
-        },
-        "i18next-conv": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/i18next-conv/-/i18next-conv-9.2.1.tgz",
-          "integrity": "sha512-RAlQIIf5BFfEywqd/1R9W4S3bGL+6qMKD/HKfnSisw9K5tSx4chQKf6pbBNzMyaoTBqWy+ZHS27ZmxE5GIGgag==",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.5.3",
-            "chalk": "^2.4.2",
-            "commander": "^2.19.0",
-            "gettext-parser": "^3.1.0",
-            "mkdirp": "^0.5.1",
-            "node-gettext": "^2.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
-        "node-gettext": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-2.1.0.tgz",
-          "integrity": "sha512-vsHImHl+Py0vB7M2UXcFEJ5NJ3950gcja45YclBFtYxYeZiqdfQdcu+G9s4L7jpRFSh/J/7VoS3upR4JM1nS+g==",
-          "dev": true,
-          "requires": {
-            "lodash.get": "^4.4.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "tablesaw": "^3.1.2"
   },
   "devDependencies": {
+    "@openculinary/i18next-gettext-loader": "^1.0.1",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^6.4.1",
     "css-loader": "^5.0.1",
@@ -35,7 +36,6 @@
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^4.5.1",
     "i18next-conv": "^10.1.0",
-    "i18next-gettext-loader": "^1.0.0",
     "i18next-scanner": "^3.0.0",
     "indexeddbshim": "^7.0.0",
     "jsdom": "^16.4.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -113,7 +113,7 @@ module.exports = (_, env) => {
                 name: 'locales/[1]/[2].json'
               }
             },
-            {loader: 'i18next-gettext-loader'}
+            {loader: '@openculinary/i18next-gettext-loader'}
           ]
         },
         {


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
As per the https://github.com/i18next/i18next/discussions/1539 thread, it's better to use a namespaced package name for the `i18next-gettext-loader` on NPM.

### Briefly summarize the changes
1. This change updates the application to use the namespaced `@openculinary/i18next-gettext-loader` package.

### How have the changes been tested?
1. Local development testing
