### PR TITLE
Revert "Best practice: prefer 'Map' objects to plain 'Object' instances"

### DIFF
--- a/src/app/state.js
+++ b/src/app/state.js
@@ -9,7 +9,7 @@ export { getState, loadPage, pushState, renderStateHash };
 function getState() {
   if (!history.state && !location.hash) return {'search': null};
   if (!history.state && location.hash) {
-    var state = new Map();
+    var state = Object.create(null);
     var urlParams = new URLSearchParams(window.location.hash.slice(1));
     urlParams.forEach((value, key) => { state[key] = value });
     return state;

--- a/src/app/views/search.js
+++ b/src/app/views/search.js
@@ -118,7 +118,7 @@ function refinementHandler(data) {
 }
 
 function getDomainStates() {
-  var domainStates = new Map();
+  var domainStates = Object.create(null);
   var state = getState();
   if (!state.domains) return domainStates;
   state.domains.split(',').forEach(domainKey => {

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -117,7 +117,7 @@ async function getProductsByCategory(servingsByRecipe) {
         if (!product) return;
         ingredientsByProduct[product.id] = ingredientsByProduct[product.id] || [];
         ingredientsByProduct[product.id].push(ingredient);
-        productsByCategory[product.category] = productsByCategory[product.category] || new Map();
+        productsByCategory[product.category] = productsByCategory[product.category] || Object.create(null);
         productsByCategory[product.category][product.id] = product;
       });
     });


### PR DESCRIPTION
This reverts commit 61ca94c1f9ab0ee4a60903eec80a8232fe6b2da3.

### Describe the reason for these changes and the problem that they solve
A migration to use `Map` objects instead of plain JavaScript objects was incomplete and had detrimental side-effects.  See #191 for some further details.

### Briefly summarize the changes
1. Revert the `Map` object migration from 61ca94c1f9ab0ee4a60903eec80a8232fe6b2da3

### How have the changes been tested?
1. Local development testing

A future change to re-introduce the `Map` object migration will include unit test coverage.

**List any issues that this change relates to**
Fixes #191 
Fixes #192 