### PR TITLE
Add a more prominent link from recipe search results to recipe details

### DIFF
--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -110,12 +110,8 @@ div.recipe-list .sidebar span {
 
 div.recipe-list .sidebar button {
   width: 192px;
-  margin-top: 1px;
+  margin-top: 4px;
   margin-bottom: 4px;
-}
-
-div.recipe-list .sidebar button.view {
-  margin-top: 8px;
 }
 
 div.recipe-list .content span.tag.badge {

--- a/src/app/views/components/recipe-list.js
+++ b/src/app/views/components/recipe-list.js
@@ -88,6 +88,19 @@ function sidebarFormatter(recipe) {
   }
 
   // TODO: i18n
+  var details = $('<a />', {'href': `#search&action=view&id=${recipe.id}`});
+  details.append($('<button />', {
+    'class': 'view btn btn-primary',
+    'text': `View recipe directions`
+  }));
+  sidebar.append(details);
+
+  sidebar.append($('<button />', {
+    'class': 'add btn btn-outline-primary add-recipe',
+    'data-i18n': i18nAttr('search:result-add-recipe')
+  }));
+
+  // TODO: i18n
   var destination = $('<a />', {
     'href': recipe.dst,
     'target': '_blank',
@@ -98,11 +111,6 @@ function sidebarFormatter(recipe) {
     'text': `View on ${recipe.domain}`
   }));
   sidebar.append(destination);
-
-  sidebar.append($('<button />', {
-    'class': 'add btn btn-outline-primary add-recipe',
-    'data-i18n': i18nAttr('search:result-add-recipe')
-  }));
 
   return sidebar;
 }


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This is a fairly small change that adds a more prominent link to the recipe detail page from each item in the recipe search results.

We may want to raise the prominence of this link even further in future; this is one step in that direction.

The text descriptions here are not yet internationalized.

### Briefly summarize the changes
1. Add a `View recipe directions` button above the `Add to meal planner` and `View on {website}` buttons in the sidebar for each recipe search result

### How have the changes been tested?
1. Local testing