### PR TITLE
Disable icons and thumbnails from the interface for now

### DIFF
--- a/src/app/views/components/recipe-list.js
+++ b/src/app/views/components/recipe-list.js
@@ -22,13 +22,11 @@ export {
 function titleFormatter(recipe) {
   var container = $('<div />', {'class': 'title'});
 
-  var icon = $('<img />', {'src': 'images/domains/' + recipe.domain + '.ico', 'alt':''});
   var title = $('<a />', {
     'href': `#search&action=view&id=${recipe.id}`,
     'text': recipe.title,
   });
 
-  container.append(icon);
   container.append(title);
 
   return container;
@@ -41,16 +39,7 @@ function starFormatter() {
 function sidebarFormatter(recipe) {
   var duration = moment.duration(recipe.time, 'minutes');
 
-  var link = $('<a />', {'href': `#search&action=view&id=${recipe.id}`});
-  var img = $('<img />', {
-    'class': 'thumbnail',
-    'src': recipe.image_url,
-    'alt': recipe.title,
-  });
-  link.append(img);
-
   var sidebar = $('<td />', {'class': 'sidebar align-top'});
-  sidebar.append(link);
 
   var properties = [
     'is_dairy_free',

--- a/src/app/views/recipe.js
+++ b/src/app/views/recipe.js
@@ -87,8 +87,6 @@ function renderRecipe() {
     var metadata = $('#recipe div.metadata').empty();
 
     var link = $('<a />', {'href': recipe.dst});
-    var img = $('<img />', {'src': recipe.image_url, 'alt': recipe.title});
-    link.append(img);
 
     if (recipe.author) {
       var author = $('<a />', {'href': recipe.author_url || recipe.dst, 'text': recipe.author});


### PR DESCRIPTION
Pending a sense that including directions is worthwhile, remove icons and thumbnails from interface.