### PR TITLE
Fixup: notification chiclet rendering improvements

### DIFF
--- a/src/app/main.css
+++ b/src/app/main.css
@@ -29,7 +29,6 @@ header div.menu {
 header span.notification {
   border-radius: 2px;
   color: white;
-  display: inline !important;
 
   padding: 1px 3px;
   font-size: 10px;

--- a/src/app/views/meals.js
+++ b/src/app/views/meals.js
@@ -161,6 +161,10 @@ function populateNotifications() {
     $('header span.notification.meal-planner').toggle(!empty);
     if (empty) return;
 
+    // TODO: Figure out why display:block is being applied incorrectly, and
+    // then remove this workaround
+    $('header span.notification.meal-planner').css({'display': 'inline'});
+
     db.meals.count(total => {
       $('header span.notification.meal-planner').text(total);
     });

--- a/src/app/views/shopping-list.js
+++ b/src/app/views/shopping-list.js
@@ -96,6 +96,10 @@ function populateNotifications() {
     $('header span.notification.shopping-list').toggle(!empty);
     if (empty) return;
 
+    // TODO: Figure out why display:block is being applied incorrectly, and
+    // then remove this workaround
+    $('header span.notification.shopping-list').css({'display': 'inline'});
+
     db.basket.count(found => {
       $('header span.notification.shopping-list').text(found + '/' + total);
     });


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
As reported in #197, something has been negatively affecting the rendering of the notification chiclets displayed above the 'meal planner' and 'shopping list' navigation links.

It turns out that this was due to incorrectly-applied `display: block` CSS styling on the elements involved.

It looks like it's jQuery that is applying `display: block`; after commenting out the [meal rendering code](https://github.com/openculinary/frontend/blob/7aacf639171d1fb588f5ebec077e14b1ecfa6c31/src/app/views/meals.js#L185-L189), no `display` CSS property is set on the meal planner chiclet on page load.

I _think_ this is somehow related to [jQuery's `showHide` function](https://github.com/jquery/jquery/blob/e1cffdef277fcf543833a20d28cbadcd000ebece/src/css/showHide.js#L34-L70) although I'm not yet exactly sure where the issue arises, and what the circumstances are.

### Briefly summarize the changes
1. When a notification chiclet is displayed, ensure that the CSS `display: inline` property is set

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Provides a more reliable approach to fix #197.