### PR TITLE
Fixup: update jayaddison/d3-sankey git commit reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "bootstrap-table": "^1.18.3",
         "convert-units": "^2.3.4",
         "d3": "^6.7.0",
-        "d3-sankey": "git://github.com/jayaddison/d3-sankey.git#44dfaafbbd3340f434bbc8b84f02acc66c1be0d9",
+        "d3-sankey": "git://github.com/jayaddison/d3-sankey.git#6e45b21baae325244662acf83a1290bfae16d97a",
         "debounce": "^1.2.1",
         "dexie": "^3.0.3",
         "dexie-observable": "^3.0.0-beta.10",
@@ -3674,8 +3674,8 @@
     },
     "node_modules/d3-sankey": {
       "version": "0.12.3",
-      "resolved": "git+ssh://git@github.com/jayaddison/d3-sankey.git#44dfaafbbd3340f434bbc8b84f02acc66c1be0d9",
-      "integrity": "sha512-qSvLV9W+Zeo/hfYY56LpjlP89MCFbZoHVFD4T7d/NHvz9NyQFc4YsY+CuRecjPUBk50uzvsRDO1o9J+XuXejeA==",
+      "resolved": "git+ssh://git@github.com/jayaddison/d3-sankey.git#6e45b21baae325244662acf83a1290bfae16d97a",
+      "integrity": "sha512-2C6ApAHr0UG3tkqItACklAdzP8+R1TEwg+NE9Qz/K8MbuJX63kam4wV1dSH3C3H/0/HBWXJIifZEQhwzAaHbdw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-array": "1 - 2",
@@ -13514,9 +13514,9 @@
       "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw=="
     },
     "d3-sankey": {
-      "version": "git+ssh://git@github.com/jayaddison/d3-sankey.git#44dfaafbbd3340f434bbc8b84f02acc66c1be0d9",
-      "integrity": "sha512-qSvLV9W+Zeo/hfYY56LpjlP89MCFbZoHVFD4T7d/NHvz9NyQFc4YsY+CuRecjPUBk50uzvsRDO1o9J+XuXejeA==",
-      "from": "d3-sankey@git://github.com/jayaddison/d3-sankey.git#44dfaafbbd3340f434bbc8b84f02acc66c1be0d9",
+      "version": "git+ssh://git@github.com/jayaddison/d3-sankey.git#6e45b21baae325244662acf83a1290bfae16d97a",
+      "integrity": "sha512-2C6ApAHr0UG3tkqItACklAdzP8+R1TEwg+NE9Qz/K8MbuJX63kam4wV1dSH3C3H/0/HBWXJIifZEQhwzAaHbdw==",
+      "from": "d3-sankey@git://github.com/jayaddison/d3-sankey.git#6e45b21baae325244662acf83a1290bfae16d97a",
       "requires": {
         "d3-array": "1 - 2",
         "d3-shape": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bootstrap-table": "^1.18.3",
     "convert-units": "^2.3.4",
     "d3": "^6.7.0",
-    "d3-sankey": "git://github.com/jayaddison/d3-sankey.git#44dfaafbbd3340f434bbc8b84f02acc66c1be0d9",
+    "d3-sankey": "git://github.com/jayaddison/d3-sankey.git#6e45b21baae325244662acf83a1290bfae16d97a",
     "debounce": "^1.2.1",
     "dexie": "^3.0.3",
     "dexie-observable": "^3.0.0-beta.10",


### PR DESCRIPTION
Attempting to perform a fresh install of the application's dependencies (as [specified in `package-lock.json`](https://github.com/openculinary/frontend/blob/6504216f8c99bcc2b567a4c3fbbf1dd22edd7e73/package-lock.json)) currently fails due to an `EINTEGRITY` error as discovered by upstream in jayaddison/d3-sankey#1.

The integrity checksum for the 'staging' branch of jayaddison/d3-sankey has been recalculated.

We can update our dependency reference to use the latest checksum and proceed.  We do not believe that the integrity of the upstream repository has been compromised, but investigation is continuing.

### Describe the reason for these changes and the problem that they solve
This allows the application's dependencies to be installed.

### Briefly summarize the changes
1. Update the dependency reference for `jayaddison/d3-sankey` to the [current latest commit](https://github.com/jayaddison/d3-sankey/commit/6e45b21baae325244662acf83a1290bfae16d97a) on the `staging` branch of that repository

### How have the changes been tested?
1. Fresh dependency reinstallation locally. 

**List any issues that this change relates to**
Relates to jayaddison/d3-sankey#1