### PR TITLE
Enable subresource integrity for HTML scripts and stylesheets

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "slipjs": "^3.0.0",
     "sortablejs": "^1.15.0",
     "tablesaw": "^3.1.2",
+    "webpack-subresource-integrity": "^5.1.0",
     "workbox-precaching": "^6.5.4",
     "workbox-routing": "^6.5.4",
     "workbox-strategies": "^6.5.4"

--- a/src/diagnostics/index.html
+++ b/src/diagnostics/index.html
@@ -22,8 +22,8 @@
     <meta name="description" content="RecipeRadar Diagnostics" />
     <meta name="theme-color" content="#07f" />
     <meta name="viewport" content="width=device-width, initial-scale=1" /><% for (index in htmlWebpackPlugin.files.css) { let integrity = htmlWebpackPlugin.files.cssIntegrity[index], href = htmlWebpackPlugin.files.css[index]; %>
-    <link integrity="<%= integrity %>" href="<%= href %>" rel="preload" as="style" crossorigin>
-    <link integrity="<%= integrity %>" href="<%= href %>" rel="stylesheet"><% } %>
+    <link integrity="<%= integrity %>" crossorigin href="<%= href %>" rel="preload" as="style">
+    <link integrity="<%= integrity %>" crossorigin href="<%= href %>" rel="stylesheet"><% } %>
     <title>RecipeRadar Diagnostics</title>
   </head>
   <body>
@@ -38,6 +38,6 @@
       </div>
     </footer>
 <% for (index in htmlWebpackPlugin.files.js) { let integrity = htmlWebpackPlugin.files.jsIntegrity[index], src = htmlWebpackPlugin.files.js[index]; %>
-    <script integrity="<%= integrity %>" src="<%= src %>" type="text/javascript"></script><% } %>
+    <script integrity="<%= integrity %>" crossorigin src="<%= src %>" type="text/javascript"></script><% } %>
   </body>
 </html>

--- a/src/diagnostics/index.html
+++ b/src/diagnostics/index.html
@@ -21,10 +21,9 @@
     <meta charset="utf-8" />
     <meta name="description" content="RecipeRadar Diagnostics" />
     <meta name="theme-color" content="#07f" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <% /* TODO: Awaiting https://caniuse.com/#feat=link-rel-preload coverage */ %>
-    <%= htmlWebpackPlugin.files.css.map(href => `<link rel="preload" href="${href}" as="style" crossorigin>`).join('\n    ') %>
-    <%= htmlWebpackPlugin.files.css.map(href => `<link rel="stylesheet" href="${href}">`).join('\n    ') %>
+    <meta name="viewport" content="width=device-width, initial-scale=1" /><% for (index in htmlWebpackPlugin.files.css) { let integrity = htmlWebpackPlugin.files.cssIntegrity[index], href = htmlWebpackPlugin.files.css[index]; %>
+    <link integrity="<%= integrity %>" href="<%= href %>" rel="preload" as="style" crossorigin>
+    <link integrity="<%= integrity %>" href="<%= href %>" rel="stylesheet"><% } %>
     <title>RecipeRadar Diagnostics</title>
   </head>
   <body>
@@ -38,7 +37,7 @@
         <small data-i18n="[html]footer:source-code"></small>
       </div>
     </footer>
-
-    <%= htmlWebpackPlugin.files.js.map(src => `<script type="text/javascript" src="${src}"></script>`).join('\n    ') %>
+<% for (index in htmlWebpackPlugin.files.js) { let integrity = htmlWebpackPlugin.files.jsIntegrity[index], src = htmlWebpackPlugin.files.js[index]; %>
+    <script integrity="<%= integrity %>" src="<%= src %>" type="text/javascript"></script><% } %>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -23,10 +23,9 @@
     <meta name="theme-color" content="#07f" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="apple-touch-icon" href="images/icons/manifest-icon-192.png">
-    <link rel="manifest" href="reciperadar.webmanifest">
-    <% /* TODO: Awaiting https://caniuse.com/#feat=link-rel-preload coverage */ %>
-    <%= htmlWebpackPlugin.files.css.map(href => `<link rel="preload" href="${href}" as="style" crossorigin>`).join('\n    ') %>
-    <%= htmlWebpackPlugin.files.css.map(href => `<link rel="stylesheet" href="${href}">`).join('\n    ') %>
+    <link rel="manifest" href="reciperadar.webmanifest"><% for (index in htmlWebpackPlugin.files.css) { let integrity = htmlWebpackPlugin.files.cssIntegrity[index], href = htmlWebpackPlugin.files.css[index]; %>
+    <link integrity="<%= integrity %>" href="<%= href %>" rel="preload" as="style" crossorigin>
+    <link integrity="<%= integrity %>" href="<%= href %>" rel="stylesheet"><% } %>
     <title>RecipeRadar - search recipes by ingredients</title>
   </head>
   <body>
@@ -385,7 +384,7 @@
         </div>
       </div>
     </footer>
-
-    <%= htmlWebpackPlugin.files.js.map(src => `<script type="text/javascript" src="${src}"${src.match(/^app\./) ? '' : ' async'}></script>`).join('\n    ') %>
+<% for (index in htmlWebpackPlugin.files.js) { let integrity = htmlWebpackPlugin.files.jsIntegrity[index], src = htmlWebpackPlugin.files.js[index]; %>
+    <script integrity="<%= integrity %>" src="<%= src %>" type="text/javascript" <%- !src.match(/^app\./) && "async" %>></script><% } %>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -24,8 +24,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="apple-touch-icon" href="images/icons/manifest-icon-192.png">
     <link rel="manifest" href="reciperadar.webmanifest"><% for (index in htmlWebpackPlugin.files.css) { let integrity = htmlWebpackPlugin.files.cssIntegrity[index], href = htmlWebpackPlugin.files.css[index]; %>
-    <link integrity="<%= integrity %>" href="<%= href %>" rel="preload" as="style" crossorigin>
-    <link integrity="<%= integrity %>" href="<%= href %>" rel="stylesheet"><% } %>
+    <link integrity="<%= integrity %>" crossorigin href="<%= href %>" rel="preload" as="style">
+    <link integrity="<%= integrity %>" crossorigin href="<%= href %>" rel="stylesheet"><% } %>
     <title>RecipeRadar - search recipes by ingredients</title>
   </head>
   <body>
@@ -385,6 +385,6 @@
       </div>
     </footer>
 <% for (index in htmlWebpackPlugin.files.js) { let integrity = htmlWebpackPlugin.files.jsIntegrity[index], src = htmlWebpackPlugin.files.js[index]; %>
-    <script integrity="<%= integrity %>" src="<%= src %>" type="text/javascript" <%- !src.match(/^app\./) && "async" %>></script><% } %>
+    <script integrity="<%= integrity %>" crossorigin src="<%= src %>" type="text/javascript" <%- !src.match(/^app\./) && "async" %>></script><% } %>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const glob = require('glob');
 
 const { InjectManifest } = require('workbox-webpack-plugin');
+const { SubresourceIntegrityPlugin } = require('webpack-subresource-integrity');
 const LicenseWebpackPlugin = require('license-webpack-plugin').LicenseWebpackPlugin;
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -24,6 +25,7 @@ module.exports = (_, env) => {
       extensions: ['.js', '.ts']
     },
     output: {
+      crossOriginLoading: 'anonymous',
       path: path.resolve(__dirname, 'public'),
       filename: (entry) => {
         if (entry.chunk.name === 'html2canvas') return 'html2canvas.js';
@@ -76,6 +78,7 @@ module.exports = (_, env) => {
         exclude: ['vendors'],
         swSrc: path.resolve(__dirname, 'src/sw/sw.js')
       }),
+      new SubresourceIntegrityPlugin({enabled: true}),
       new HtmlWebpackPlugin({
         excludeChunks: ['diagnostics', 'locales'],
         template: path.resolve(__dirname, 'src/index.html'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5680,6 +5680,11 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
+typed-assert@^1.0.8:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/typed-assert/-/typed-assert-1.0.9.tgz#8af9d4f93432c4970ec717e3006f33f135b06213"
+  integrity sha512-KNNZtayBCtmnNmbo5mG47p1XsCyrx6iVqomjcZnec/1Y5GGARaxPs6r49RnSPeUP3YjNYiU9sQHAtY4BBvnZwg==
+
 typescript@^4.8.3:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
@@ -5935,6 +5940,13 @@ webpack-sources@^3.0.0, webpack-sources@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
+
+webpack-subresource-integrity@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-subresource-integrity/-/webpack-subresource-integrity-5.1.0.tgz#8b7606b033c6ccac14e684267cb7fb1f5c2a132a"
+  integrity sha512-sacXoX+xd8r4WKsy9MvH/q/vBtEHr86cpImXwyg74pFIpERKt6FmB8cXpeuh0ZLgclOlHI4Wcll7+R5L02xk9Q==
+  dependencies:
+    typed-assert "^1.0.8"
 
 webpack@^5.74.0:
   version "5.74.0"


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
When retrieving and caching resources (like scripts and stylesheets) using content delivery networks or other mirroring mechanisms, it's a good idea to provide an integrity value to the client before they retrieve those resources, so that the client can verify that the resources they've retrieved match the expected content.

This project uses [`HTMLWebpackPlugin`](https://github.com/jantimon/html-webpack-plugin.git/) to build and bundle the (static) web application contents placed into the container image, and there is a [`webpack-subresource-integrity`](https://github.com/waysact/webpack-subresource-integrity.git/) plugin available to use with it.

### Briefly summarize the changes
1. Add the `webpack-subresource-integrity` plugin as a development dependency
1. Attach `integrity` attributes to stylesheet and script items in the application's bundled HTML

### How have the changes been tested?
1. Local build of the project in both `development` and `production` webpack modes and inspection of the resulting HTML