### PR TITLE
Migration: use unicode characters instead of font-based glyphs

### DIFF
--- a/etc/nginx/conf.d/expires.conf
+++ b/etc/nginx/conf.d/expires.conf
@@ -1,7 +1,5 @@
 map $sent_http_content_type $expires {
     application/javascript 1y;
-    font/woff 1y;
-    font/woff2 1y;
     image/png 1y;
     image/x-icon 1y;
     text/css 1y;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "frontend",
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^6.2.0",
     "@popperjs/core": "^2.11.6",
     "bootstrap": "^5.2.1",
     "bootstrap-table": "^1.21.1",

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,5 +1,3 @@
-import '@fortawesome/fontawesome-free/css/fontawesome.min.css';
-import '@fortawesome/fontawesome-free/css/all.min.css';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap-table/dist/bootstrap-table.css';
 import 'select2/dist/css/select2.css';

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -48,7 +48,7 @@ function attributionFormatter(recipe: Recipe) : JQuery {
 }
 
 function starFormatter() {
-  return $('<div />', {'class': 'star far fa-star'});
+  return $('<div />', {'class': 'star', 'html': '&#x2b50;'});
 }
 
 function thumbnailFormatter(recipe) : JQuery {

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -219,8 +219,6 @@ function updateStarState(selector: string, recipeId: string) : void {
     const isStarred = !!starred;
 
     const star = $(`${selector} div.recipe-list .recipe[data-id="${recipeId}"] .star`);
-    star.toggleClass('fas', isStarred);
-    star.toggleClass('far', !isStarred);
     star.css('color', isStarred ? 'gold' : 'dimgray');
     star.off('click');
     star.on('click', () => {

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -48,7 +48,7 @@ function attributionFormatter(recipe: Recipe) : JQuery {
 }
 
 function starFormatter() {
-  return $('<div />', {'class': 'star', 'html': '&#x2b50;'});
+  return $('<div />', {'class': 'star', 'html': '&#x269d;'});
 }
 
 function thumbnailFormatter(recipe) : JQuery {
@@ -219,7 +219,7 @@ function updateStarState(selector: string, recipeId: string) : void {
     const isStarred = !!starred;
 
     const star = $(`${selector} div.recipe-list .recipe[data-id="${recipeId}"] .star`);
-    star.css('color', isStarred ? 'gold' : 'dimgray');
+    star.html(isStarred ? '&#x2b50;' : '&#x269d;');
     star.off('click');
     star.on('click', () => {
       const toggleStarred = isStarred ? unstarRecipe : starRecipe;

--- a/src/app/views/meals.ts
+++ b/src/app/views/meals.ts
@@ -51,16 +51,18 @@ function recipeElement(recipe: Recipe, meal?: Meal) {
   });
 
   const remove = $('<a />', {
-    'class': 'remove fa fa-trash-alt',
-    'style': 'float: right; margin-left: 8px; margin-top: 3px;'
+    'class': 'remove',
+    'style': 'float: right; margin-left: 8px; margin-top: 3px;',
+    'html': '&#x1f5d1',
   });
   remove.on('click', () => { getRecipe(remove).then(removeRecipe).then(updateRecipeState) });
 
   // TODO: only include 'servings' parameter when the value overrides the recipe default
   // This may require some data model refactoring
   const link = $('<a />', {
-    'class': 'link fa fa-link',
-    'href': `#search&action=view&id=${recipe.id}&servings=${recipe.servings}`
+    'class': 'link',
+    'href': `#search&action=view&id=${recipe.id}&servings=${recipe.servings}`,
+    'html': '&#x1f517;'
   });
   const item = $('<div />', {'style': 'float: left'});
   item.append(link);
@@ -98,12 +100,14 @@ function pushSchedulerNavigation() {
 }
 
 function schedulerNavigationHyperlink(target, targetDate) {
+  const arrow = target == 'forward' ? '&#x21d2;' : '&#x21d0';
   const date = targetDate.format('YYYY-MM-DD');
   return $('<a />', {
-    'class': `${target} fas fa-${target}`,
+    'class': target,
     'click': pushSchedulerNavigation,
     'data-date': date,
-    'href': `#meal-planner&start-date=${date}`
+    'href': `#meal-planner&start-date=${date}`,
+    'html': arrow
   });
 }
 

--- a/src/app/views/search.css
+++ b/src/app/views/search.css
@@ -7,8 +7,7 @@
 }
 
 #search .prompt + span {
-  vertical-align: top;
-  margin-top: 20px;
+  vertical-align: middle;
   margin-left: 2rem;
 }
 

--- a/src/app/views/search.css
+++ b/src/app/views/search.css
@@ -6,7 +6,7 @@
   padding-top: 0;
 }
 
-#search .prompt + span.fa {
+#search .prompt + span {
   vertical-align: top;
   margin-top: 20px;
   margin-left: 2rem;
@@ -19,10 +19,10 @@
   clear: both;
 }
 
-#search .include + .fa { color: #70f070; }
-#search .exclude + .fa { color: #f07070; }
+#search .include + span { color: #70f070; }
+#search .exclude + span { color: #f07070; }
 #search .exclude span.tag.badge-info { background-color: #ff5050; }
-#search .equipment + .fa { color: #7070f0; }
+#search .equipment + span { color: #7070f0; }
 #search .equipment span.tag.badge-info { background-color: #b0b0ff; }
 
 #search .dietary-properties ~ ul {

--- a/src/index.html
+++ b/src/index.html
@@ -78,13 +78,13 @@
           <div class="card-body row">
             <div class="col">
               <div class="prompt include" data-i18n="[html]search:prompt-get-started"></div>
-              <span class="fa fa-chevron-circle-right"></span>
+              <span>&#x29c1;</span>
               <select id="include" multiple></select>
               <div class="prompt exclude" data-i18n="[html]search:prompt-exclude"></div>
-              <span class="fa fa-minus-circle"></span>
+              <span>&#x229d;</span>
               <select id="exclude" multiple></select>
               <div class="prompt equipment" data-i18n="[html]search:prompt-equipment"></div>
-              <span class="fa fa-cog"></span>
+              <span>&#x2699;</span>
               <select id="equipment" multiple></select>
             </div class="col">
             <div class="col">

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,11 +941,6 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@fortawesome/fontawesome-free@^6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-6.2.0.tgz#ba3510825b332816fe7190f28827f8cb33a298b5"
-  integrity sha512-CNR7qRIfCwWHNN7FnKUniva94edPdyQzil/zCwk3v6k4R6rR2Fr8i4s3PM7n/lyfPA6Zfko9z5WDzFxG9SW1uQ==
-
 "@humanwhocodes/config-array@^0.11.6":
   version "0.11.7"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.7.tgz#38aec044c6c828f6ed51d5d7ae3d9b9faf6dbb0f"


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Learning about subresource integrity as part of #213 led to some re-evaluation of the resources loaded by the application at startup.

It wasn't clear to me how to configure subresource integrity on font files loaded using CSS, and so it seemed worth spending some time to look at alternative options.

Standardized unicode characters are available that are near-or-exact replacements for all of the font-based glyph icons in use throughout the application.

So: we can reduce our dependencies, reduce the bundled application size (and network requests), and work around the question of subresource integrity for fonts temporarily by migrating to unicode-based characters instead of font glyphs.

The reduction in bundle size appears to be from ~3MB down to ~2MB - a fairly significant saving.

The main negative trade-off is that the user experience may be less slick.  This is likely to be a particular concern for any systems that do not have some of the relatively-recently-added unicode characters referenced in the change (for example, `U+1F5D1` added in Unicode 7.0 in 2014).

### Briefly summarize the changes
1. Use unicode icons instead of font-based glyphs throughout the application

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Considered as a result of #213.