### PR TITLE
Search results: adjust appearance of ingredients within search results

### DIFF
--- a/src/app/recipeml.ts
+++ b/src/app/recipeml.ts
@@ -14,7 +14,7 @@ function renderIngredientHTML(ingredient: Ingredient) : HTMLElement {
     container.append($('<div />', {'class': 'quantity', 'html': quantityHTML}));
 
     $(xml.childNodes).remove('amt');
-    $(xml).find('ingredient').replaceWith((idx, text) => $('<span />', {'class': 'product tag badge', 'text': text}).addClass(ingredient.product && ingredient.product.state));
+    $(xml).find('ingredient').replaceWith((idx, text) => $('<span />', {'class': 'product', 'text': text}).addClass(ingredient.product && ingredient.product.state));
     container.append($('<div />', {'class': 'ingredient', 'html': xml.childNodes}));
 
     return container.html();
@@ -24,7 +24,7 @@ function renderDirectionHTML(direction: Direction) : HTMLElement {
     const xml = $.parseXML(`<xml>${direction.markup}</xml>`).firstChild;
     const container = $('<div />');
 
-    $(xml).find('mark[class*=equipment]').replaceWith((idx, text) => $('<span />', {'class': 'equipment tag badge', 'text': text}));
+    $(xml).find('mark[class*=equipment]').replaceWith((idx, text) => $('<span />', {'class': 'equipment', 'text': text}));
     $(xml).find('mark[class*=action]').replaceWith((idx, text) => $('<span />', {'class': 'action', 'text': text}));
     const directionHTML = $('<li />', {'class': 'direction', 'html': xml.childNodes});
 

--- a/src/app/recipeml.ts
+++ b/src/app/recipeml.ts
@@ -14,7 +14,7 @@ function renderIngredientHTML(ingredient: Ingredient) : HTMLElement {
     container.append($('<div />', {'class': 'quantity', 'html': quantityHTML}));
 
     $(xml.childNodes).remove('amt');
-    $(xml).find('ingredient').replaceWith((idx, text) => $('<span />', {'class': 'tag badge', 'text': text}).addClass(ingredient.product && ingredient.product.state));
+    $(xml).find('ingredient').replaceWith((idx, text) => $('<span />', {'class': 'product tag badge', 'text': text}).addClass(ingredient.product && ingredient.product.state));
     container.append($('<div />', {'class': 'ingredient', 'html': xml.childNodes}));
 
     return container.html();

--- a/src/app/recipeml.ts
+++ b/src/app/recipeml.ts
@@ -15,7 +15,7 @@ function renderIngredientHTML(ingredient: Ingredient) : HTMLElement {
 
     $(xml.childNodes).remove('amt');
     $(xml).find('ingredient').replaceWith((idx, text) => $('<span />', {'class': 'tag badge', 'text': text}).addClass(ingredient.product && ingredient.product.state));
-    container.append($('<div />', {'class': 'product', 'html': xml.childNodes}));
+    container.append($('<div />', {'class': 'ingredient', 'html': xml.childNodes}));
 
     return container.html();
 }

--- a/src/app/recipeml.ts
+++ b/src/app/recipeml.ts
@@ -14,7 +14,7 @@ function renderIngredientHTML(ingredient: Ingredient) : HTMLElement {
     container.append($('<div />', {'class': 'quantity', 'html': quantityHTML}));
 
     $(xml.childNodes).remove('amt');
-    $(xml).find('ingredient').replaceWith((idx, text) => $('<span />', {'class': 'product', 'text': text}).addClass(ingredient.product && ingredient.product.state));
+    $(xml).find('ingredient').replaceWith((idx, text) => $('<span />', {'class': 'product', 'text': text}).addClass(ingredient.product.state));
     container.append($('<div />', {'class': 'ingredient', 'html': xml.childNodes}));
 
     return container.html();

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -138,14 +138,13 @@ div.recipe-list .content .ingredients .ingredient {
 }
 
 div.recipe-list .content .ingredients .ingredient .product {
-  color: black;
-  font-weight: normal;
-  padding: 0;
+  text-decoration-color: silver;
+  text-decoration-line: underline;
+  text-decoration-thickness: 2px;
 }
 
 div.recipe-list .content .ingredients .ingredient .product.available {
-  color: green;
-  font-weight: bold;
+  text-decoration-color: orange;
 }
 
 div.recipe-list button.add-recipe {

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -118,17 +118,6 @@ div.recipe-list .sidebar span {
   padding-bottom: 0.3rem;
 }
 
-div.recipe-list .content span.tag.badge {
-  color: black;
-  font-weight: normal;
-  padding: 0;
-}
-
-div.recipe-list .content span.tag.badge.available {
-  color: green;
-  font-weight: bold; 
-}
-
 div.recipe-list .content .ingredients {
   margin-left: 1rem;
   display: grid;
@@ -146,6 +135,17 @@ div.recipe-list .content .ingredients .quantity {
 div.recipe-list .content .ingredients .ingredient {
   grid-column: 2;
   color: gray;
+}
+
+div.recipe-list .content span.tag.badge {
+  color: black;
+  font-weight: normal;
+  padding: 0;
+}
+
+div.recipe-list .content span.tag.badge.available {
+  color: green;
+  font-weight: bold; 
 }
 
 div.recipe-list button.add-recipe {

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -145,7 +145,7 @@ div.recipe-list .content span.tag.badge {
 
 div.recipe-list .content span.tag.badge.available {
   color: green;
-  font-weight: bold; 
+  font-weight: bold;
 }
 
 div.recipe-list button.add-recipe {

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -137,13 +137,13 @@ div.recipe-list .content .ingredients .ingredient {
   color: gray;
 }
 
-div.recipe-list .content span.tag.badge {
+div.recipe-list .content .ingredients .ingredient .product {
   color: black;
   font-weight: normal;
   padding: 0;
 }
 
-div.recipe-list .content span.tag.badge.available {
+div.recipe-list .content .ingredients .ingredient .product.available {
   color: green;
   font-weight: bold;
 }

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -134,7 +134,6 @@ div.recipe-list .content .ingredients .quantity {
 
 div.recipe-list .content .ingredients .ingredient {
   grid-column: 2;
-  color: gray;
 }
 
 div.recipe-list .content .ingredients .ingredient .product {

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -143,7 +143,7 @@ div.recipe-list .content .ingredients .quantity {
   text-align: right;
 }
 
-div.recipe-list .content .ingredients .product {
+div.recipe-list .content .ingredients .ingredient {
   grid-column: 2;
   color: gray;
 }


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This changeset attempts to improve the appearance and legibility of ingredient description lines within the search results.

Previously, the default colour for text in ingredient lines was the HTML CSS colour `gray`, resulting in relatively low-contrast text.  Product names within the text were displayed differently (in `black`, usually -- with the exception of search terms, coloured `green`) to distinguish them from the surrounding descriptive text.

Instead, it seems better to use a single colour for all text within ingredient lines.  To achieve annotation/highlighting of product names, we instead use underlines.  Search terms are displayed with an `orange` underline, and other product names are underlined with a `gray` underline.

**Before**
![image](https://user-images.githubusercontent.com/55152140/199749620-82444c04-96d0-4657-b28a-c07601053538.png)

**After**
![image](https://user-images.githubusercontent.com/55152140/199749696-6c384afe-7e55-40ff-af56-0a0df090c205.png)

### Briefly summarize the changes
1. Rectify / cleanup a few CSS rules and element names (and their associated RecipeML processing)
1. Use underlines instead of font styling to identify products within ingredient lines

### How have the changes been tested?
1. Local development testing