### PR TITLE
Fixup: prevent duplicate-of-current navigation entries from being placed into the application navigation history

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -2,6 +2,8 @@ const { JSDOM } = require('jsdom');
 const dom = new JSDOM('<html />');
 
 global.document = dom.window.document;
+global.history = dom.window.history;
+global.navigator = dom.window.navigator;
 global.window = dom.window;
 global.self = dom.window;
 

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -18,6 +18,7 @@ function getState() : Record<string, string> {
 }
 
 function pushState(state: Record<string, string>, hash: string) : void {
+  if (window.location.hash === hash) return;
   history.pushState(state, '', hash);
 }
 

--- a/src/app/views/explore.ts
+++ b/src/app/views/explore.ts
@@ -13,7 +13,7 @@ function pushExplore() {
   // If the requested search is a repeat of the current state, perform a results refresh
   // This is done to ensure that the results are scrolled into view
   const stateHash: string = renderStateHash(state);
-  if (`#${window.location.hash}` === stateHash) {
+  if (window.location.hash === stateHash) {
     $('#explore table[data-row-attributes]').trigger('page-change.bs.table');
   }
   pushState(state, stateHash);

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -29,7 +29,7 @@ function pushSearch() : void {
   // If the requested search is a repeat of the current state, perform a results refresh
   // This is done to ensure that the results are scrolled into view
   const stateHash = renderStateHash(state);
-  if (`#${window.location.hash}` === stateHash) {
+  if (window.location.hash === stateHash) {
     $('#search table[data-row-attributes]').trigger('page-change.bs.table');
   }
   pushState(state, stateHash);

--- a/test/state.js
+++ b/test/state.js
@@ -1,0 +1,11 @@
+import * as assert from 'assert';
+
+import { pushState } from '../src/app/state';
+
+describe('duplicate state attempts', function() {
+  assert.equal(1, window.history.length);
+  pushState({}, '#example');
+  window.history.go();
+  pushState({}, '#example');
+  assert.equal(2, window.history.length);
+})


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Using the 'back' button to navigate from the meal planner -- or any other page in the application -- to a search results page was causing the search results page to be added _twice_ in the navigation history.

This part of the code has changed a few times and various bugs like this have appeared.  It would be worth investing time to improve test coverage of common workflows, to reduce the chance that similar problems will be (re)introduced in future.

There may also be redundancy and/or inefficiency in the current navigation logic; it has developed somewhat organically.  The process of adding test coverage would likely help to uncover a more robust and streamlined implementation.

### Briefly summarize the changes
1. When adding entries to the applications navigation history, perform a check to see whether the entry matches the current navigation location.  If it does, then that location should already be in the navigation history, and we don't add it again.

### How have the changes been tested?
1. Basic unit test coverage is added