### PR TITLE
Attempt to simplify scroll-to-results logic in the application

### DIFF
--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -189,8 +189,6 @@ function bindPageChange(selector: string) : void {
 
     const stateHash: string = renderStateHash(state);
     pushState(state, stateHash);
-
-    scrollToResults(selector, 50);
   });
 }
 

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -17,6 +17,7 @@ export {
     bindLoadEvent,
     recipeFormatter,
     rowAttributes,
+    scrollToResults,
     updateRecipeState,
 };
 

--- a/src/app/views/explore.ts
+++ b/src/app/views/explore.ts
@@ -10,15 +10,9 @@ export { renderExplore };
 function pushExplore() {
   const state = {'explore': null, 'action': 'explore'};
 
-  // If the requested search is a repeat of the current state, perform a results refresh
-  // This is done to ensure that the results are scrolled into view
   const stateHash: string = renderStateHash(state);
-  if (window.location.hash === stateHash) {
-    scrollToResults('#explore');
-  } else {
-    pushState(state, stateHash);
-    $(window).trigger('popstate');
-  }
+  pushState(state, stateHash);
+  $(window).trigger('popstate');
 }
 $('#explore form button').on('click', pushExplore);
 

--- a/src/app/views/explore.ts
+++ b/src/app/views/explore.ts
@@ -10,12 +10,6 @@ export { renderExplore };
 function pushExplore() {
   const state = {'explore': null, 'action': 'explore'};
 
-  // If the requested search is a repeat of the current state, perform a results refresh
-  // This is done to ensure that the results are scrolled into view
-  const stateHash: string = renderStateHash(state);
-  if (window.location.hash === stateHash) {
-    $('#explore table[data-row-attributes]').trigger('page-change.bs.table');
-  }
   pushState(state, stateHash);
   $(window).trigger('popstate');
 }

--- a/src/app/views/explore.ts
+++ b/src/app/views/explore.ts
@@ -10,6 +10,7 @@ export { renderExplore };
 function pushExplore() {
   const state = {'explore': null, 'action': 'explore'};
 
+  const stateHash: string = renderStateHash(state);
   pushState(state, stateHash);
   $(window).trigger('popstate');
 }

--- a/src/app/views/explore.ts
+++ b/src/app/views/explore.ts
@@ -3,7 +3,7 @@ import Slip from 'slipjs';
 
 import { localize } from '../i18n';
 import { getState, pushState, renderStateHash } from '../state';
-import { initTable } from './components/recipe-list';
+import { initTable, scrollToResults } from './components/recipe-list';
 
 export { renderExplore };
 

--- a/src/app/views/explore.ts
+++ b/src/app/views/explore.ts
@@ -10,9 +10,15 @@ export { renderExplore };
 function pushExplore() {
   const state = {'explore': null, 'action': 'explore'};
 
+  // If the requested search is a repeat of the current state, perform a results refresh
+  // This is done to ensure that the results are scrolled into view
   const stateHash: string = renderStateHash(state);
-  pushState(state, stateHash);
-  $(window).trigger('popstate');
+  if (window.location.hash === stateHash) {
+    scrollToResults('#explore');
+  } else {
+    pushState(state, stateHash);
+    $(window).trigger('popstate');
+  }
 }
 $('#explore form button').on('click', pushExplore);
 

--- a/src/app/views/explore.ts
+++ b/src/app/views/explore.ts
@@ -3,7 +3,7 @@ import Slip from 'slipjs';
 
 import { localize } from '../i18n';
 import { getState, pushState, renderStateHash } from '../state';
-import { initTable, scrollToResults } from './components/recipe-list';
+import { initTable } from './components/recipe-list';
 
 export { renderExplore };
 

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -26,15 +26,9 @@ function pushSearch() : void {
   const sortChoice = getState().sort;
   if (sortChoice) state['sort'] = sortChoice;
 
-  // If the requested search is a repeat of the current state, perform a results refresh
-  // This is done to ensure that the results are scrolled into view
   const stateHash: string = renderStateHash(state);
-  if (window.location.hash === stateHash) {
-    scrollToResults('#search');
-  } else {
-    pushState(state, stateHash);
-    triggerSearch();
-  }
+  pushState(state, stateHash);
+  triggerSearch();
 }
 $('#search form button').on('click', pushSearch);
 

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -7,7 +7,7 @@ import { getRecipeById } from '../common';
 import { i18nAttr, localize } from '../i18n';
 import { getState, pushState, renderStateHash } from '../state';
 import { scaleRecipe } from '../models/recipes';
-import { initTable, bindLoadEvent } from './components/recipe-list';
+import { initTable, bindLoadEvent, scrollToResults } from './components/recipe-list';
 
 export { renderRecipe, renderSearch };
 
@@ -26,12 +26,6 @@ function pushSearch() : void {
   const sortChoice = getState().sort;
   if (sortChoice) state['sort'] = sortChoice;
 
-  // If the requested search is a repeat of the current state, perform a results refresh
-  // This is done to ensure that the results are scrolled into view
-  const stateHash = renderStateHash(state);
-  if (window.location.hash === stateHash) {
-    $('#search table[data-row-attributes]').trigger('page-change.bs.table');
-  }
   pushState(state, stateHash);
   triggerSearch();
 }
@@ -218,4 +212,5 @@ $(function() {
   bindLoadEvent('#search', refinementHandler);
   bindLoadEvent('#search', domainFacetsHandler);
   bindLoadEvent('#search', addSorting);
+  bindLoadEvent('#search', scrollToResults);
 });

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -37,8 +37,13 @@ function renderRecipe() : void {
   getRecipeById(state.id).then(recipe => {
     scaleRecipe(recipe, Number(state.servings) || recipe.servings);
     const recipeList = $('#search table[data-row-attributes]');
-    recipeList.bootstrapTable('load', [recipe]);
-    recipeList.trigger('load-success.bs.table');
+    const searchResults = [recipe];
+    recipeList.bootstrapTable('load', searchResults);
+    recipeList.trigger('load-success.bs.table', {
+      authority: 'local',
+      results: searchResults,
+      total: searchResults.length
+    });
   });
 }
 

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -213,5 +213,5 @@ $(function() {
   bindLoadEvent('#search', refinementHandler);
   bindLoadEvent('#search', domainFacetsHandler);
   bindLoadEvent('#search', addSorting);
-  bindLoadEvent('#search', scrollToResults);
+  bindLoadEvent('#search', () => scrollToResults('#search'));
 });

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -26,6 +26,7 @@ function pushSearch() : void {
   const sortChoice = getState().sort;
   if (sortChoice) state['sort'] = sortChoice;
 
+  const stateHash: string = renderStateHash(state);
   pushState(state, stateHash);
   triggerSearch();
 }

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -38,7 +38,7 @@ function renderRecipe() : void {
     scaleRecipe(recipe, Number(state.servings) || recipe.servings);
     const recipeList = $('#search table[data-row-attributes]');
     recipeList.bootstrapTable('load', [recipe]);
-    recipeList.trigger('page-change.bs.table');
+    recipeList.trigger('load-success.bs.table');
   });
 }
 

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -26,9 +26,15 @@ function pushSearch() : void {
   const sortChoice = getState().sort;
   if (sortChoice) state['sort'] = sortChoice;
 
+  // If the requested search is a repeat of the current state, perform a results refresh
+  // This is done to ensure that the results are scrolled into view
   const stateHash: string = renderStateHash(state);
-  pushState(state, stateHash);
-  triggerSearch();
+  if (window.location.hash === stateHash) {
+    scrollToResults('#search');
+  } else {
+    pushState(state, stateHash);
+    triggerSearch();
+  }
 }
 $('#search form button').on('click', pushSearch);
 

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -220,5 +220,5 @@ $(function() {
   bindLoadEvent('#search', refinementHandler);
   bindLoadEvent('#search', domainFacetsHandler);
   bindLoadEvent('#search', addSorting);
-  bindLoadEvent('#search', () => scrollToResults('#search'));
+  bindLoadEvent('#search', () => scrollToResults('#search', 50));
 });

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -41,8 +41,10 @@ function renderRecipe() : void {
     recipeList.bootstrapTable('load', searchResults);
     recipeList.trigger('load-success.bs.table', {
       authority: 'local',
+      total: searchResults.length,
       results: searchResults,
-      total: searchResults.length
+      facets: {},
+      refinements: []
     });
   });
 }

--- a/src/sw/sw.js
+++ b/src/sw/sw.js
@@ -12,8 +12,10 @@ addEventListener('message', (event) => {
 function returnEmptyResults() {
   var response = {
     authority: 'local',
+    total: 0,
     results: [],
-    total: 0
+    facets: {},
+    refinements: []
   };
   return new Response(JSON.stringify(response), {'status': 200});
 }


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
When the application loads recipes for display -- whether an individual item from local cache, or a set of results from the API -- we generally want to scroll the viewpoint so that the top result is displayed to the user.

The logic to perform this is a bit fragmented at the moment; it relates in some ways to navigation state, in some ways to `bootstrap-table`, and in some ways to the different logic that the application contains for each view (tab).  It is partially but not completely abstracted by the shared `recipe-list` view component.

This changeset removes some likely-faulty old logic related to page state discovered during #217.

The changeset also attempts to simplify the intended logic by invoking the scroll event directly.

### Briefly summarize the changes
1. Update pseudo-results responses (local-authority, empty fallback) to match the current API authority response format
1. Add a `scrollToResults` call to the load-successful event handler for the recipe search results list component
1. Emit load-successful events instead of page-change events when 'local' (non-fetched) recipe results are loaded

### How have the changes been tested?
1. Browser-based testing; not thorough, and not ideal

**List any issues that this change relates to**
Discovered during #217.