### PR TITLE
Hide the domain filter contents when there are more than 10 domains in the facet results

### DIFF
--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -160,7 +160,7 @@ function domainFacetsHandler(data) : void {
   $.each(data.facets.domains, function() {
     domainFacets.append(renderDomainFacet(this, domainStates[this.key]));
   });
-  domainFacets.toggleClass('collapse', data.facets.domains.length > 10 || $.isEmptyObject(data.facets.domains));
+  domainFacets.toggleClass('collapse', $.isEmptyObject(data.facets.domains) || data.facets.domains.length > 10);
 }
 
 function createSortPrompt() : void {

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -160,7 +160,7 @@ function domainFacetsHandler(data) : void {
   $.each(data.facets.domains, function() {
     domainFacets.append(renderDomainFacet(this, domainStates[this.key]));
   });
-  domainFacets.toggleClass('collapse', $.isEmptyObject(data.facets.domains));
+  domainFacets.toggleClass('collapse', data.facets.domains.length > 10 || $.isEmptyObject(data.facets.domains));
 }
 
 function createSortPrompt() : void {


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
When there are a large number of domains in the domain-filter list, it becomes difficult to display them on-screen when viewport size is limited, and also usability suffers when a large list of checkbox options is presented with an unclear sort order.

### Briefly summarize the changes
1. Only display up to ten (10) domains to filter on

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Resolves #219.