### PR TITLE
Migration: switch to upstream / packaged d3-sankey library

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bootstrap-table": "^1.21.2",
     "convert-units": "^2.3.4",
     "d3": "^7.7.0",
-    "d3-sankey": "git+https://github.com/jayaddison/d3-sankey.git#4139e71e15ba146f1ca66bef27177c1ac8cbdb66",
+    "d3-sankey": "^0.12.3",
     "debounce": "^1.2.1",
     "dexie": "3.2.2",
     "dexie-observable": "^3.0.0-beta.11",

--- a/src/app/dialogs/about.ts
+++ b/src/app/dialogs/about.ts
@@ -13,8 +13,7 @@ declare global {
 }
 window.jQuery = $;
 
-// TODO: import d3-sankey without referencing the node_modules directory
-import { sankeyTop } from '../../../node_modules/d3-sankey/src';
+import { sankey as sankeyInstance, sankeyLinkHorizontal } from 'd3-sankey';
 import * as data from './about-diagram.json';
 
 export {};
@@ -32,25 +31,25 @@ $('#about-modal').on('shown.bs.modal', function() {
 function renderDiagram() {
   const container = $('#about-modal div.modal-body');
   const margin = { top: 5, right: 5, bottom: 5, left: 5 };
-  const width = container.width() - margin.left - margin.right;
-  const height = 300 - margin.top - margin.bottom;
+  const width = container.width();
+  const height = 300 + margin.top + margin.bottom;
 
   const svg = d3
       .select('#about-modal div.chart')
       .append('svg')
-      .attr('width', width + margin.left + margin.right)
+      .attr('width', width)
       .attr('height', height + margin.top + margin.bottom)
       .append('g')
-      .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+      .attr('transform', 'rotate(90 ' + (height / 2) + ' ' + (height) + ') translate(' + (-height / 2) + ',' + (- (margin.left + margin.right)) + ')');
 
-  const sankey = sankeyTop()
+  const sankey = sankeyInstance()
       .size([width, height])
       .nodeId(d => d.name)
       .nodeWidth(20)
       .nodePadding(10)
       .extent([
           [0, 5],
-          [width, height - 5]
+          [height, width - 5]
       ]);
 
   const graph = sankey(data);
@@ -73,7 +72,7 @@ function renderDiagram() {
       .data(graph.links)
       .join('g')
       .append('path')
-      .attr('d', sankey.linkShape())
+      .attr('d', sankeyLinkHorizontal())
       .attr('class', 'link')
       .attr('stroke-width', 16)
       .append('title').text(d => `${d.source.name} →  ${d.target.name}`);
@@ -87,5 +86,6 @@ function renderDiagram() {
       .attr('y', d => (d.y1 + d.y0) / 2)
       .attr('dy', '0.2em')
       .attr('text-anchor', 'middle')
+      .attr('transform', d => 'rotate(-90 ' + ((d.x0 + d.x1) / 2) + ' ' + ((d.y1 + d.y0) / 2) + ')')
       .text(d => d.name);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2222,9 +2222,10 @@ d3-random@3:
   resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
   integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
 
-"d3-sankey@git+https://github.com/jayaddison/d3-sankey.git#4139e71e15ba146f1ca66bef27177c1ac8cbdb66":
+d3-sankey@^0.12.3:
   version "0.12.3"
-  resolved "git+https://github.com/jayaddison/d3-sankey.git#4139e71e15ba146f1ca66bef27177c1ac8cbdb66"
+  resolved "https://registry.yarnpkg.com/d3-sankey/-/d3-sankey-0.12.3.tgz#b3c268627bd72e5d80336e8de6acbfec9d15d01d"
+  integrity sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==
   dependencies:
     d3-array "1 - 2"
     d3-shape "^1.2.0"


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
We've been using a [fork of `d3-sankey`](https://github.com/jayaddison/d3-sankey.git/) that provides 'native' vertical diagram orientations.  However, it doesn't appear that the implemented functionality is likely to be accepted by upstream.

That's fine, although we have also experienced some wonkiness related to `package.json`-related handling of `git`-ref-published dependencies, and generally it seems wise to use (and help maintain) the same versions of codebases as the larger community. 

Since we do want to maintain vertical display of sankey diagrams, we can use SVG's built-in `rotate` transformation to adjust the rendering of the diagram.

![image](https://user-images.githubusercontent.com/55152140/209989509-2f4c757a-e5a7-4fd8-acc0-ab2aa5e0e7bb.png)

### Briefly summarize the changes
1. Switch to the published, packaged `d3-sankey` library distribution
1. Use SVG `rotate` transformations to adjust the library's horizontal rendering format for vertical display in the application

### How have the changes been tested?
1. Local development testing