### PR TITLE
Use iframes with content integrity for embedded licensing content

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -336,9 +336,11 @@
             </div>
             <div class="tab-pane" id="about-license" role="tabpanel">
               <p>RecipeRadar is licensed under the GNU AGPLv3.</p>
-              <object class="container-fluid" data="LICENSE" type="text/plain">The license to this software is bundled with the application and is also <a href="https://github.com/openculinary/frontend/blob/b2bcab413b424d9b6e1a64db16777beccdfb6ba7/LICENSE">available to read online.</a></object>
+              <iframe integrity="sha512-/VmsC2zX+w/AMx3VBBib2r3ICkFlHUUfRDxxdF593TGHc2D3oWgaHmZsXhQdXR5iMJAS+DGQ8YaCAiFzXu+sWQ==" class="container-fluid" src="LICENSE"></iframe>
+              <p>The license to this software is bundled with the application and is also <a integrity="sha512-/VmsC2zX+w/AMx3VBBib2r3ICkFlHUUfRDxxdF593TGHc2D3oWgaHmZsXhQdXR5iMJAS+DGQ8YaCAiFzXu+sWQ==" href="https://github.com/openculinary/frontend/blob/b2bcab413b424d9b6e1a64db16777beccdfb6ba7/LICENSE">available to read online.</a></p>
               <p>Included below are the licenses for the dependencies of this application.</p>
-              <object class="container-fluid" data="licenses.txt" type="text/plain">The license for the packages that this application depends upon are <a href="licenses.txt">available to read here.</a></object>
+              <iframe integrity="sha512-aADxYbK+HWZYHpWLA4E8gwLJwdwidg2keAYiBZYhMIj7AeC0dCB/y8mj+QEqFBbYSdXFEypEgrHu3ludVn/qaw==" class="container-fluid" src="licenses.txt"></iframe>
+              <p>The license for the packages that this application depends upon are <a integrity="sha512-aADxYbK+HWZYHpWLA4E8gwLJwdwidg2keAYiBZYhMIj7AeC0dCB/y8mj+QEqFBbYSdXFEypEgrHu3ludVn/qaw==" href="licenses.txt">available to read here.</a></p>
             </div>
           </div>
           <div class="modal-footer">

--- a/src/index.html
+++ b/src/index.html
@@ -339,6 +339,7 @@
               <iframe integrity="sha512-/VmsC2zX+w/AMx3VBBib2r3ICkFlHUUfRDxxdF593TGHc2D3oWgaHmZsXhQdXR5iMJAS+DGQ8YaCAiFzXu+sWQ==" class="container-fluid" src="LICENSE"></iframe>
               <p>The license to this software is bundled with the application and is also <a integrity="sha512-/VmsC2zX+w/AMx3VBBib2r3ICkFlHUUfRDxxdF593TGHc2D3oWgaHmZsXhQdXR5iMJAS+DGQ8YaCAiFzXu+sWQ==" href="https://github.com/openculinary/frontend/blob/b2bcab413b424d9b6e1a64db16777beccdfb6ba7/LICENSE">available to read online.</a></p>
               <p>Included below are the licenses for the dependencies of this application.</p>
+              <!-- TODO: Use webpack build to embed integrity hashes for 'licenses.txt'; see https://github.com/waysact/webpack-subresource-integrity/issues/208 -->
               <iframe integrity="sha512-aADxYbK+HWZYHpWLA4E8gwLJwdwidg2keAYiBZYhMIj7AeC0dCB/y8mj+QEqFBbYSdXFEypEgrHu3ludVn/qaw==" class="container-fluid" src="licenses.txt"></iframe>
               <p>The license for the packages that this application depends upon are <a integrity="sha512-aADxYbK+HWZYHpWLA4E8gwLJwdwidg2keAYiBZYhMIj7AeC0dCB/y8mj+QEqFBbYSdXFEypEgrHu3ludVn/qaw==" href="licenses.txt">available to read here.</a></p>
             </div>


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Adds subresource integrity for embedded licensing (the AGPLv3 license that the application uses, and the collection of licensing information for the application's dependencies).

### Briefly summarize the changes
1. Use HTML `iframe` elements instead of HTML `object` elements to include the licensing information
2. Add `integrity` attributes to the `iframe` elements, anticipating a future HTML subresource integrity spec

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Resolves #228.