### PR TITLE
Restore ability to run unit tests

### DIFF
--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,5 +1,3 @@
-import 'bootstrap/dist/css/bootstrap.css';
-import 'bootstrap-table/dist/bootstrap-table.css';
 import 'select2/dist/css/select2.css';
 import 'tablesaw/dist/stackonly/tablesaw.stackonly.css';
 
@@ -20,6 +18,10 @@ import './views/components/recipe-list.css';
 import './main.css';
 
 import './database';
+
+import 'bootstrap-table';
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-table/dist/bootstrap-table.css';
 
 import { recipeFormatter, rowAttributes } from './views/components/recipe-list';
 export { recipeFormatter, rowAttributes };

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -20,7 +20,7 @@ export {
     updateRecipeState,
 };
 
-function attributionFormatter(recipe: Recipe) : JQuery {
+function attributionFormatter(recipe: Recipe) : $ {
   const container = $('<div />', {'class': 'attribution'});
 
   const title = $('<a />', {
@@ -49,7 +49,7 @@ function starFormatter() {
   return $('<div />', {'class': 'star', 'html': '&#x269d;'});
 }
 
-function thumbnailFormatter(recipe) : JQuery {
+function thumbnailFormatter(recipe) : $ {
   const container = $('<td />', {'class': 'thumbnail align-top'});
   const link = $('<a />', {'href': recipe.dst});
   const img = $('<img />', {
@@ -62,7 +62,7 @@ function thumbnailFormatter(recipe) : JQuery {
   return container;
 }
 
-function sidebarFormatter(recipe) : JQuery {
+function sidebarFormatter(recipe) : $ {
   const duration = Duration.fromObject({minutes: recipe.time}, {locale: resolvedLocale()});
 
   const sidebar = $('<td />', {'class': 'sidebar align-top'});

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -236,7 +236,9 @@ function bindPostBody(selector: string) : void {
     $(this).find('button.add-recipe').each((_, button) => {
       $(button).on('click', () => { getRecipe(button).then(addRecipe).then(updateRecipeState); });
     });
-    $(this).parents('div.recipe-list').show();
+    if (data && data.length) {
+      $(this).parents('div.recipe-list').show();
+    }
 
     // Localize search result elements
     localize(selector);

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -1,5 +1,4 @@
 import * as $ from 'jquery';
-import 'bootstrap-table';
 import { debounce } from 'debounce';
 
 import '../autosuggest';
@@ -74,7 +73,7 @@ function renderSearch() : void {
   });
 }
 
-function renderRefinement(refinement: string) : JQuery {
+function renderRefinement(refinement: string) : $ {
   if (refinement == 'empty_query') {
     return $('<div />', {
       'data-i18n': i18nAttr('search:refinement-empty-query')
@@ -104,7 +103,7 @@ function updateStateDomains() : void {
     debouncedSearchTrigger();
 }
 
-function renderDomainFacet(domain: Record<string, string>, state?: boolean) : JQuery {
+function renderDomainFacet(domain: Record<string, string>, state?: boolean) : $ {
   const domainState = state === undefined ? true : state;
   const chip = $('<label />', {'class': 'badge bg-light rounded-pill text-dark'});
   const checkbox = $('<input />', {'type': 'checkbox', 'checked': domainState, 'value': domain.key});


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve

### Briefly summarize the changes
1. Revert 9a0848597a1f701e12f6516e4d86adc5085b1efd, moving the import of `bootstrap-table`.
    * `bootstrap-table` added a `"type": "module"` declaration in `package.json` in version 1.21.3 -- this appears to have conflicted with the ability to run unit tests here.
2. Since the revert affects uncovers a timing issue related to display of an empty search recipe list on the homepage (it reopens #230), also add a conditional before we call JQuery's `show` method on the recipe results.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Fixes #233.