### PR TITLE
Developer experience: enable additional linting rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,8 +12,7 @@
     "ignorePatterns": [
         "src/diagnostics/*.js",
         "src/feedback/*.js",
-        "src/sw/loader.js",
-        "src/sw/sw.js"
+        "src/sw/*.js"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,10 +7,22 @@
     },
     "extends": [
         "eslint:recommended",
-        "plugin:@typescript-eslint/recommended"
+        "plugin:@typescript-eslint/recommended-type-checked"
     ],
     "ignorePatterns": [
-        "src/feedback/*.js"
+        "src/diagnostics/*.js",
+        "src/feedback/*.js",
+        "src/sw/sw.js"
     ],
-    "parser": "@typescript-eslint/parser"
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "project": true
+    },
+    "rules": {
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-return": "off"
+    }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     "ignorePatterns": [
         "src/diagnostics/*.js",
         "src/feedback/*.js",
+        "src/sw/loader.js",
         "src/sw/sw.js"
     ],
     "parser": "@typescript-eslint/parser",

--- a/src/app/common.ts
+++ b/src/app/common.ts
@@ -4,7 +4,7 @@ import { Recipe, db } from './database';
 
 export { getMealId, getRecipe, getRecipeById };
 
-async function getMealId(el: HTMLElement) : Promise<string> {
+function getMealId(el: HTMLElement) : Promise<string> {
   const target = $(el).hasClass('recipe') ? $(el) : $(el).parents('.recipe');
   return target.data('meal-id');
 }

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -26,7 +26,7 @@ function resolvedLocale() : string {
   return i18next.resolvedLanguage;
 }
 
-i18next && i18next.use(BrowserLanguage).use(HTTP).init({
+i18next && void i18next.use(BrowserLanguage).use(HTTP).init({
   ns: [
     'categories',
     'dietary-properties',

--- a/src/app/models/ingredients.ts
+++ b/src/app/models/ingredients.ts
@@ -16,7 +16,7 @@ function addStandaloneIngredient(product: Product) : void {
 }
 
 function removeStandaloneIngredient(product: Product) : void {
-  db.ingredients
+  void db.ingredients
     .where("[recipe_id+product_id+index]")
     .between(
       ['', product.id, db.minKey()],

--- a/src/app/models/meals.ts
+++ b/src/app/models/meals.ts
@@ -4,5 +4,5 @@ import { db } from '../database';
 export { removeMeal };
 
 function removeMeal() : void {
-  getMealId(this).then(mealId => { db.meals.delete(mealId); });
+  void getMealId(this).then(mealId => { void db.meals.delete(mealId); });
 }

--- a/src/app/models/products.ts
+++ b/src/app/models/products.ts
@@ -4,12 +4,12 @@ export { addProduct };
 
 function addProduct(ingredient: Ingredient, recipeId: string, index: number) : void {
   const product = ingredient.product;
-  db.transaction('rw', db.products, db.ingredients, () => {
-    db.products.put({
+  void db.transaction('rw', db.products, db.ingredients, () => {
+    void db.products.put({
       id: product.id,
       ...product
     });
-    db.ingredients.add({
+    void db.ingredients.add({
       recipe_id: recipeId,
       product_id: product.id,
       index: index,

--- a/src/app/models/recipes.ts
+++ b/src/app/models/recipes.ts
@@ -7,7 +7,7 @@ export { addRecipe, removeRecipe, scaleRecipe };
 
 async function addRecipe(recipe: Recipe) : Promise<string> {
   return db.transaction('rw', db.recipes, db.products, db.ingredients, () => {
-    db.recipes.add(recipe).then(() => {
+    void db.recipes.add(recipe).then(() => {
       $.each(recipe.ingredients, (index, ingredient) => {
         addProduct(ingredient, recipe.id, index);
       });
@@ -17,13 +17,13 @@ async function addRecipe(recipe: Recipe) : Promise<string> {
 
 async function removeRecipe(recipe: Recipe) : Promise<string> {
   return db.transaction('rw', db.recipes, db.meals, db.ingredients, () => {
-    db.recipes
+    void db.recipes
       .delete(recipe.id);
-    db.meals
+    void db.meals
       .where("recipe_id")
       .equals(recipe.id)
       .delete();
-    db.ingredients
+    void db.ingredients
       .where("recipe_id")
       .equals(recipe.id)
       .delete();

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -193,7 +193,7 @@ function bindPageChange(selector: string) : void {
 }
 
 function updateRecipeState(recipeId: string) : void {
-  db.recipes.get(recipeId, (recipe?: Recipe) => {
+  void db.recipes.get(recipeId, (recipe?: Recipe) => {
     const isInRecipes = !!recipe;
 
     const addButton = $(`div.recipe-list .recipe[data-id="${recipeId}"] button.add-recipe`);
@@ -214,7 +214,7 @@ function updateServings(recipe: Recipe) : void {
 }
 
 function updateStarState(selector: string, recipeId: string) : void {
-  db.starred.get(recipeId, (starred?: Starred) => {
+  void db.starred.get(recipeId, (starred?: Starred) => {
     const isStarred = !!starred;
 
     const star = $(`${selector} div.recipe-list .recipe[data-id="${recipeId}"] .star`);
@@ -222,7 +222,7 @@ function updateStarState(selector: string, recipeId: string) : void {
     star.off('click');
     star.on('click', () => {
       const toggleStarred = isStarred ? unstarRecipe : starRecipe;
-      getRecipe(star).then(toggleStarred).then(recipeId => { updateStarState(selector, recipeId) });
+      void getRecipe(star).then(toggleStarred).then(recipeId => { updateStarState(selector, recipeId) });
     });
   });
 }
@@ -235,10 +235,10 @@ function bindPostBody(selector: string) : void {
     });
 
     $(this).find('input.servings').each((_, input) => {
-      $(input).on('change', () => { getRecipe(input).then(updateServings); });
+      $(input).on('change', () => { void getRecipe(input).then(updateServings); });
     });
     $(this).find('button.add-recipe').each((_, button) => {
-      $(button).on('click', () => { getRecipe(button).then(addRecipe).then(updateRecipeState); });
+      $(button).on('click', () => { void getRecipe(button).then(addRecipe).then(updateRecipeState); });
     });
     if (data && data.length) {
       $(this).parents('div.recipe-list').show();

--- a/src/app/views/meals.ts
+++ b/src/app/views/meals.ts
@@ -22,7 +22,7 @@ function defaultDate() {
 }
 
 function updateHints() {
-  db.recipes.count(count => {
+  void db.recipes.count(count => {
     const hints: string[] = [];
     if (count) {
         hints.push($('<p />', {'data-i18n': i18nAttr('meal-planner:hint-drag')}));
@@ -56,7 +56,7 @@ function recipeElement(recipe: Recipe, meal?: Meal) {
     'style': 'float: right; margin-left: 8px; margin-top: 3px;',
     'html': '&#x1f5d1',
   });
-  remove.on('click', () => { getRecipe(remove).then(removeRecipe).then(updateRecipeState) });
+  remove.on('click', () => { void getRecipe(remove).then(removeRecipe).then(updateRecipeState) });
 
   // TODO: only include 'servings' parameter when the value overrides the recipe default
   // This may require some data model refactoring
@@ -84,7 +84,7 @@ function recipeElement(recipe: Recipe, meal?: Meal) {
 
 function renderRecipes() {
   const container = $('#meal-planner .recipes').empty();
-  db.recipes.each(recipe => {
+  void db.recipes.each(recipe => {
     container.append(recipeElement(recipe));
   });
 
@@ -141,9 +141,9 @@ function renderMeals() {
     scheduler.append(row);
   }
 
-  db.transaction('r', db.meals, db.recipes, () => {
-    db.meals.each(meal => {
-      db.recipes.get(meal.recipe_id, recipe => {
+  void db.transaction('r', db.meals, db.recipes, () => {
+    void db.meals.each(meal => {
+      void db.recipes.get(meal.recipe_id, recipe => {
         const cell = $(`#meal-planner table tr[data-date="${meal.datetime}"] td`);
         cell.append(recipeElement(recipe, meal));
       });
@@ -168,7 +168,7 @@ function dragMeal(evt) {
   elements.forEach(function (element) {
     const recipeRemove = $(element).find('a.remove');
     recipeRemove.off('click');
-    recipeRemove.on('click', () => { getRecipe(recipeRemove).then(removeRecipe).then(updateRecipeState) });
+    recipeRemove.on('click', () => { void getRecipe(recipeRemove).then(removeRecipe).then(updateRecipeState) });
 
     const mealRemove = $(element).find('span[data-role="remove"]');
     mealRemove.off('click');
@@ -177,13 +177,13 @@ function dragMeal(evt) {
 }
 
 function scheduleMeal(evt) {
-  getRecipe(evt.item).then(recipe => {
+  void getRecipe(evt.item).then(recipe => {
     const toRow = $(evt.to).parents('tr');
     if (!toRow.length) return;
     const date = toRow.data('date');
     // TODO: Can we avoid duplicate work across getRecipe and getMealId calls here?
-    getMealId(evt.item).then(mealId => {
-      db.meals.put({
+    void getMealId(evt.item).then(mealId => {
+      void db.meals.put({
         id: mealId,
         recipe_id: recipe.id,
         datetime: date,
@@ -196,7 +196,7 @@ function scheduleMeal(evt) {
 }
 
 function populateNotifications() {
-  db.recipes.count(count => {
+  void db.recipes.count(count => {
     const empty: boolean = count === 0;
     $('header span.notification.meal-planner').toggle(!empty);
     if (empty) return;
@@ -205,7 +205,7 @@ function populateNotifications() {
     // then remove this workaround
     $('header span.notification.meal-planner').css({'display': 'inline'});
 
-    db.meals.count(total => {
+    void db.meals.count(total => {
       $('header span.notification.meal-planner').text(total);
     });
   });

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -33,7 +33,7 @@ $('#search form button').on('click', pushSearch);
 
 function renderRecipe() : void {
   const state = getState();
-  getRecipeById(state.id).then(recipe => {
+  void getRecipeById(state.id).then(recipe => {
     scaleRecipe(recipe, Number(state.servings) || recipe.servings);
     const recipeList = $('#search table[data-row-attributes]');
     const searchResults = [recipe];

--- a/src/app/views/starred.ts
+++ b/src/app/views/starred.ts
@@ -8,9 +8,9 @@ import { initTable } from './components/recipe-list';
 export {};
 
 function renderStarred() {
-  db.starred.toCollection().keys(keys => {
+  void db.starred.toCollection().keys(keys => {
     const promises = keys.map((key: string) => getRecipeById(key));
-    Promise.all(promises).then(recipes => {
+    void Promise.all(promises).then(recipes => {
       const recipeList = $('#starred-recipes table[data-row-attributes]');
       recipeList.bootstrapTable('load', recipes);
       recipeList.bootstrapTable('refreshOptions', {


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Enables some additional linting rules provided by `@typescript-eslint` (in fact, enables the `recommended-type-checked` base ruleset, but with a few items selectively disabled).  This is done to catch more errors (particularly datatype-related errors) [earlier during the development lifecycle](https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20100036670.pdf).

### Briefly summarize the changes
1. Enable the [`recommended-type-checked` ruleset](https://typescript-eslint.io/blog/announcing-typescript-eslint-v6#reworked-configuration-names) in the project's `eslintrc`.
2. Disable a few rules that have a combination of high frequency with low value throughout the codebase.

### How have the changes been tested?
1. `make lint` has been used to check that the rules are enabled and that the lint tooling considers that the codebase adheres to them.

**List any issues that this change relates to**
N/A