### PR TITLE
Workaround: delay state-restoration until the JavaScript cycle after jQuery document is loaded

### DIFF
--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -110,5 +110,5 @@ $(function() {
   });
 
   window.onpopstate = loadState;
-  loadState();
+  setTimeout(loadState, 0);
 });


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This is a workaround for a fairly high-importance issue, #242.

~~Something about the `webpack` minimization of our application appears to break the loading/display of search results from valid hyperlinks where results should be shown, as described in #242.~~

~~Until we can pinpoint exactly what is going wrong during minimization, having those links load correctly will be a better user experience.~~

Webpack minimization appears to have been a red herring here; there may have been a race condition that minimization either exacerbates, or it was simply a coincidence that disabling minimization made no difference and that manual testing passed purely based on probability.

To avoid an apparent race condition when loading `bootstrap-table` and initiating result-loading, here we add delay to the application's initial [`loadState` call](https://github.com/openculinary/frontend/blob/a443d6f99549037e6e53d57c87d540075d24f9c8/src/app/state.ts#L113).  The `loadState` function can initiate a result-display operation, involving a server-AJAX call, if the state indicates that recipe search results should be displayed.

Arguably this may be a workaround, but it appears to solve the problem reliably.  We should figure out a more minimal repro for this, and may be able to report the problem upstream.

### Briefly summarize the changes
1. ~~Disable `webpack` minification.~~
2. Delay the application's `loadState` call by using [`setTimeout`](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout) with a `delay` of zero.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Resolves #241.
Resolves #237.