### PR TITLE
Fixup: meal-planner and shopping-list notification chiclet updates

### DIFF
--- a/src/app/common.ts
+++ b/src/app/common.ts
@@ -4,9 +4,9 @@ import { Recipe, db } from './database';
 
 export { getMealId, getRecipe, getRecipeById };
 
-function getMealId(el: HTMLElement) : Promise<string> {
+async function getMealId(el: HTMLElement) : Promise<string> {
   const target = $(el).hasClass('recipe') ? $(el) : $(el).parents('.recipe');
-  return target.data('meal-id');
+  return await target.data('meal-id');
 }
 
 async function getRecipeById(recipeId: string) : Promise<Recipe> {

--- a/src/app/views/shopping-list.ts
+++ b/src/app/views/shopping-list.ts
@@ -200,6 +200,7 @@ $(function() {
 
   db.on('changes', changes => { changes.find(c => c.table === 'meals') && renderShoppingList() });
   db.on('changes', changes => { changes.find(c => c.table === 'ingredients') && renderShoppingList() });
+  db.on('changes', changes => { changes.find(c => c.table === 'basket') && populateNotifications() });
 
   renderShoppingList();
 })


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Fixes two separate issues that caused the Meal Planner and Shopping List notification chiclets to fail to update after user meal plan and shopping list edits. 

### Briefly summarize the changes
1. Add an event handler for client application `basket` database table modifications.
1. Fix a bug introduced in 1da4edfe63e799e1a4e41a208325acf23c5ad90a that caused planned meals not to be written to the client application `meals` database table.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Resolves #244.