### PR TITLE
Add a 'Content Security Policy', using an HTML meta http-equiv tag

### DIFF
--- a/src/app/views/explore.ts
+++ b/src/app/views/explore.ts
@@ -75,4 +75,6 @@ $(function() {
   window['Slip']('#explore-choices .next', {keepSwipingPercent: 10});
   $('#explore-choices .next').on('slip:beforereorder', preventReorder);
   $('#explore-choices .next').on('slip:swipe', swipeHandler);
+
+  $('#explore form').on('submit', () => false);
 });

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -222,4 +222,6 @@ $(function() {
   bindLoadEvent('#search', domainFacetsHandler);
   bindLoadEvent('#search', addSorting);
   bindLoadEvent('#search', () => scrollToResults('#search', 50));
+
+  $('#search form').on('submit', () => false);
 });

--- a/src/index.html
+++ b/src/index.html
@@ -364,7 +364,7 @@
         </div>
       </div>
     </footer>
-<% for (index in htmlWebpackPlugin.files.js) { let integrity = htmlWebpackPlugin.files.jsIntegrity[index], src = htmlWebpackPlugin.files.js[index]; %>
+<% for (index in htmlWebpackPlugin.files.js.filter(filename => !filename.match(/^html2canvas\./))) { let integrity = htmlWebpackPlugin.files.jsIntegrity[index], src = htmlWebpackPlugin.files.js[index]; %>
     <script integrity="<%= integrity %>" crossorigin src="<%= src %>" type="text/javascript" <%- src.match(/^app\./) ? "" : "async" %>></script><% } %>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -341,7 +341,7 @@
               <p>The license to this software is bundled with the application and is also <a integrity="sha512-/VmsC2zX+w/AMx3VBBib2r3ICkFlHUUfRDxxdF593TGHc2D3oWgaHmZsXhQdXR5iMJAS+DGQ8YaCAiFzXu+sWQ==" href="https://github.com/openculinary/frontend/blob/b2bcab413b424d9b6e1a64db16777beccdfb6ba7/LICENSE">available to read online.</a></p>
               <p>Included below are the licenses for the dependencies of this application.</p>
               <!-- TODO: Use webpack build to embed integrity hashes for 'licenses.txt'; see https://github.com/waysact/webpack-subresource-integrity/issues/208 -->
-              <iframe integrity="sha512-o6DS6gqdJIIvWGZIslq5kdleCvrVLwdbNovEGegFfuVYbl9bbaAxQytWbXIHZzSaeSfDl6kk7mevn2juALpsmA==" class="container-fluid" src="licenses.txt"></iframe>
+              <iframe integrity="sha512-RE8oJtQ5ifPOo00TFYwmynOkzpJt8Dwznp+fpqGvo7l0l1Aq9FOvJvFuSMZxJ5KOZPTCgMnggV3cUx2gCYSZrA==" class="container-fluid" src="licenses.txt"></iframe>
               <p>The license for the packages that this application depends upon are <a integrity="sha512-o6DS6gqdJIIvWGZIslq5kdleCvrVLwdbNovEGegFfuVYbl9bbaAxQytWbXIHZzSaeSfDl6kk7mevn2juALpsmA==" href="licenses.txt">available to read here.</a></p>
             </div>
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -19,6 +19,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; media-src 'none'; object-src 'none'; script-src 'self' <% for (index in htmlWebpackPlugin.files.js) { %>'<%= htmlWebpackPlugin.files.jsIntegrity[index] %>' <% } %>; style-src 'self' 'unsafe-inline';" />
     <meta name="description" content="RecipeRadar - search recipes by ingredients" />
     <meta name="theme-color" content="#07f" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/index.html
+++ b/src/index.html
@@ -55,7 +55,7 @@
 
     <div id="search" class="container">
       <div class="card-deck mb-4 pt-3">
-        <form class="card" onsubmit="return false">
+        <form class="card">
           <div class="card-body row">
             <div class="col">
               <div class="prompt include" data-i18n="[html]search:prompt-get-started"></div>
@@ -122,7 +122,7 @@
 
     <div id="explore" class="container collapse">
       <div class="card-deck mb-4 pt-3">
-        <form class="card" onsubmit="return false">
+        <form class="card">
           <div class="card-body">
             <div class="prompt" data-i18n="[html]explore:prompt-get-started"></div>
             <div id="explore-choices">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = (_, env) => {
       'app': path.resolve(__dirname, 'src/app/main.ts'),
       'diagnostics': path.resolve(__dirname, 'src/diagnostics/main.js'),
       'feedback': path.resolve(__dirname, 'src/feedback/loader.js'),
+      'html2canvas': path.resolve(__dirname, `node_modules/html2canvas/dist/${html2canvas}`),
       'locales': glob.sync('./i18n/locales/translations/*/*.po'),
       'sw': path.resolve(__dirname, 'src/sw/loader.js')
     },
@@ -25,7 +26,10 @@ module.exports = (_, env) => {
     output: {
       crossOriginLoading: 'anonymous',
       path: path.resolve(__dirname, 'public'),
-      filename: '[name].[contenthash].js',
+      filename: (entry) => {
+        if (entry.chunk.name === 'html2canvas') return 'html2canvas.js';
+        return '[name].[contenthash].js';
+      },
       libraryTarget: 'var',
       library: '[name]'
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,10 +40,6 @@ module.exports = (_, env) => {
             name: 'RecipeML',
             directory: path.join(__dirname, 'src', 'RecipeML')
           },
-          {
-            name: 'html2canvas',
-            directory: path.join(__dirname, 'node_modules', 'html2canvas')
-          }
         ],
         handleMissingLicenseText: (package) => { throw Error(`Could not determine license for ${package}`) },
         licenseTypeOverrides: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,11 +61,6 @@ module.exports = (_, env) => {
           toType: 'file'
         },
         {
-          from: `node_modules/html2canvas/dist/${html2canvas}`,
-          to: 'html2canvas.js',
-          toType: 'file'
-        },
-        {
           from: `static/images/icons/${env && env.mode || 'development'}/`,
           to: 'images/icons/',
           toType: 'dir'


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The user interface uses JavaScript code and is generally written to be careful not to accept any untrusted outside data.  However, the recipes that it displays contain data originally gathered from the web, and although they're unlikely to contain any problems, it's good to be cautious where possible.

In particular what we are worried about is [Cross-Site-Scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) vulnerabilities, abbreviated XSS for short.  Basically: content that is not intrinsically part of the website/app code, but that is loaded within it from some external source, and that could cause problems for the user (bugs, data leakage, annoying messages, or other effects).

However, other similar vulnerabilities are also possible - unexpected [CSS](https://www.w3.org/Style/CSS/Overview.en.html) (page styling), images, plugins, audio or video could be loaded unexpectedly.

[Content Security Policy](https://www.w3.org/TR/CSP3/) is, in approximate language, a way for an application to declare "these are the places that content is expected to arrive from" -- and if an attempt is made to load/display content from other locations, it can be denied (or reported).

### Briefly summarize the changes
* Add a Content Security Policy to the application.
  * By default, only content from the origin webserver (RecipeRadar, first-party) is allowed.
  * Images can additionally be loaded from [`data:` URLs](https://developer.mozilla.org/en-US/docs/web/http/basics_of_http/data_urls) (this is only needed for the `html2canvas` in-browser-screenshot component, used when users provide feedback)
  * Videos, audio and HTML `<object>` plugins are not allowed.
  * A specific set of scripts are allowed, and only from the origin webserver.
  * Stylesheets (CSS) are given some lenience to apply inline styles (again this is required for `html2canvas` since it applies inline styles when creating an in-browser screenshot for user feedback purposes).

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
N/A