### PR TITLE
Database access bug: temporarily downgrade typescript and bootstrap-table dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@popperjs/core": "2.11.8",
         "bootstrap": "5.3.3",
-        "bootstrap-table": "1.23.5",
+        "bootstrap-table": "1.22.6",
         "convert-units": "2.3.4",
         "d3": "7.9.0",
         "d3-sankey": "0.12.3",
@@ -3321,9 +3321,9 @@
       }
     },
     "node_modules/bootstrap-table": {
-      "version": "1.23.5",
-      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.23.5.tgz",
-      "integrity": "sha512-9WByoSpJvA73gi2YYIlX6IWR74oZtBmSixul/Th8FTBtBd/kZRpbKESGTjhA3BA3AYTnfyY8Iy1KeRWPlV2GWQ==",
+      "version": "1.22.6",
+      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.22.6.tgz",
+      "integrity": "sha512-thyvL2B1J0rkRtHgfEAOiHZGXsGbxyd+uBPX/5JEB+RE+6Efu2+T67sd8I5kxdXkkoGAAPEsHH7iRI3iT8GkJg==",
       "peerDependencies": {
         "jquery": "3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "mocha": "10.7.3",
         "ts-loader": "9.5.1",
         "ts-node": "10.9.2",
-        "typescript": "5.6.3",
+        "typescript": "5.5.4",
         "typescript-eslint": "8.9.0",
         "webpack": "5.95.0",
         "webpack-cli": "5.1.4",
@@ -5240,20 +5240,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -9029,9 +9015,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mocha": "10.7.3",
     "ts-loader": "9.5.1",
     "ts-node": "10.9.2",
-    "typescript": "5.6.3",
+    "typescript": "5.5.4",
     "typescript-eslint": "8.9.0",
     "webpack": "5.95.0",
     "webpack-cli": "5.1.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@popperjs/core": "2.11.8",
     "bootstrap": "5.3.3",
-    "bootstrap-table": "1.23.5",
+    "bootstrap-table": "1.22.6",
     "convert-units": "2.3.4",
     "d3": "7.9.0",
     "d3-sankey": "0.12.3",


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Rollback two application dependencies that appear to have a problematic interaction with this application's codebase, causing failures to access the in-browser Dexie database (but likely unrelated to any Dexie code).

### Briefly summarize the changes
1. Downgrade `typescript` to v5.5.4
1. Downgrade `bootstrap-table` to v1.22.6

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Partially reverts ebd969ded66394589c7ce81a439d7871745392dd.
Resolves #255.