### PR TITLE
Recipe List: configure table row styles using bootstrap-table 'rowStyle' setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@popperjs/core": "2.11.8",
         "bootstrap": "5.3.3",
-        "bootstrap-table": "1.22.6",
+        "bootstrap-table": "1.23.5",
         "convert-units": "2.3.4",
         "d3": "7.9.0",
         "d3-sankey": "0.12.3",
@@ -50,7 +50,7 @@
         "mocha": "10.7.3",
         "ts-loader": "9.5.1",
         "ts-node": "10.9.2",
-        "typescript": "5.5.4",
+        "typescript": "5.6.3",
         "typescript-eslint": "8.9.0",
         "webpack": "5.95.0",
         "webpack-cli": "5.1.4",
@@ -3321,9 +3321,9 @@
       }
     },
     "node_modules/bootstrap-table": {
-      "version": "1.22.6",
-      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.22.6.tgz",
-      "integrity": "sha512-thyvL2B1J0rkRtHgfEAOiHZGXsGbxyd+uBPX/5JEB+RE+6Efu2+T67sd8I5kxdXkkoGAAPEsHH7iRI3iT8GkJg==",
+      "version": "1.23.5",
+      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.23.5.tgz",
+      "integrity": "sha512-9WByoSpJvA73gi2YYIlX6IWR74oZtBmSixul/Th8FTBtBd/kZRpbKESGTjhA3BA3AYTnfyY8Iy1KeRWPlV2GWQ==",
       "peerDependencies": {
         "jquery": "3"
       }
@@ -5239,6 +5239,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -9015,9 +9029,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@popperjs/core": "2.11.8",
     "bootstrap": "5.3.3",
-    "bootstrap-table": "1.22.6",
+    "bootstrap-table": "1.23.5",
     "convert-units": "2.3.4",
     "d3": "7.9.0",
     "d3-sankey": "0.12.3",
@@ -45,7 +45,7 @@
     "mocha": "10.7.3",
     "ts-loader": "9.5.1",
     "ts-node": "10.9.2",
-    "typescript": "5.5.4",
+    "typescript": "5.6.3",
     "typescript-eslint": "8.9.0",
     "webpack": "5.95.0",
     "webpack-cli": "5.1.4",

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -23,5 +23,5 @@ import 'bootstrap-table';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap-table/dist/bootstrap-table.css';
 
-import { recipeFormatter, rowAttributes } from './views/components/recipe-list';
-export { recipeFormatter, rowAttributes };
+import { recipeFormatter, rowAttributes, rowStyle } from './views/components/recipe-list';
+export { recipeFormatter, rowAttributes, rowStyle };

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -16,6 +16,7 @@ export {
     bindLoadEvent,
     recipeFormatter,
     rowAttributes,
+    rowStyle,
     scrollToResults,
     updateRecipeState,
 };
@@ -165,10 +166,11 @@ function recipeFormatter(value: HTMLElement, recipe: Recipe) : HTMLElement {
 }
 
 function rowAttributes(row: HTMLElement) : Record<string, string> {
-  return {
-    'class': 'recipe',
-    'data-id': row.id
-  }
+  return {'data-id': row.id};
+}
+
+function rowStyle() : Record<string, string> {
+  return {'classes': 'recipe'};
 }
 
 function scrollToResults(selector: string, delay?: number) : void {

--- a/src/index.html
+++ b/src/index.html
@@ -110,6 +110,7 @@
           data-pagination-loop="false"
           data-pagination-v-align="both"
           data-row-attributes="app.rowAttributes"
+          data-row-style="app.rowStyle"
           data-smart-display="true"
           data-side-pagination="server"
           data-toggle="table">
@@ -148,6 +149,7 @@
           data-pagination-loop="false"
           data-pagination-v-align="both"
           data-row-attributes="app.rowAttributes"
+          data-row-style="app.rowStyle"
           data-smart-display="true"
           data-side-pagination="server"
           data-toggle="table">
@@ -170,6 +172,7 @@
           data-pagination-loop="false"
           data-pagination-v-align="both"
           data-row-attributes="app.rowAttributes"
+          data-row-style="app.rowStyle"
           data-smart-display="true"
           data-toggle="table">
           <thead hidden="hidden">


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve

### Briefly summarize the changes
1. Fix a bug that caused `getRecipe` lookups to fail for table rows within the recipe search results, due to a lack of CSS `recipe` classname.
1. Previously the CSS classname had been added by the `bootstrap-table` `rowAttributes` setting -- however, there is a purpose-defined `rowStyle` setting available, so begin using that instead.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
- Provides a more robust fix for #255 than #256 does.
- Reverts #256.