### PR TITLE
Redesign: omit recipe image thumbnails and relocate (optional) nutritional info there

### DIFF
--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -43,10 +43,6 @@ div.recipe-list td {
   border: none;
 }
 
-div.recipe-list td.thumbnail {
-  width: 200px;
-}
-
 div.recipe-list td.sidebar {
   width: 200px;
 }
@@ -73,16 +69,6 @@ div.recipe-list .star {
 
 div.recipe-list .recipe table {
   clear: both;
-}
-
-div.recipe-list .thumbnail {
-  width: 240px;
-}
-
-div.recipe-list .thumbnail img {
-  margin-left: 16px;
-  margin-bottom: 16px;
-  max-width: 192px;
 }
 
 div.recipe-list .sidebar div.heading {

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -43,6 +43,10 @@ div.recipe-list td {
   border: none;
 }
 
+div.recipe-list td.nutrition {
+  width: 200px;
+}
+
 div.recipe-list td.sidebar {
   width: 200px;
 }
@@ -69,6 +73,29 @@ div.recipe-list .star {
 
 div.recipe-list .recipe table {
   clear: both;
+}
+
+div.recipe-list .nutrition {
+  width: 240px;
+}
+
+div.recipe-list .nutrition div.heading {
+  width: 100%;
+  text-align: center;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+div.recipe-list .nutrition span.field {
+  width: 90px;
+  text-align: right;
+}
+
+div.recipe-list .nutrition span {
+  display: inline-block;
+  margin-left: 1rem;
+  padding-top: 0.3rem;
+  padding-bottom: 0.3rem;
 }
 
 div.recipe-list .sidebar div.heading {

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -131,6 +131,7 @@ div.recipe-list .sidebar span {
 }
 
 div.recipe-list .content .ingredients {
+  margin-top: 1rem;
   margin-left: 1rem;
   display: grid;
   grid-row-gap: 0.25em;

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -98,6 +98,10 @@ div.recipe-list .nutrition span {
   padding-bottom: 0.3rem;
 }
 
+div.recipe-list .sidebar input.servings {
+  margin-top: 0.6rem;
+}
+
 div.recipe-list .sidebar span.field {
   width: 90px;
   text-align: right;

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -98,13 +98,6 @@ div.recipe-list .nutrition span {
   padding-bottom: 0.3rem;
 }
 
-div.recipe-list .sidebar div.heading {
-  width: 100%;
-  text-align: center;
-  margin-top: 1rem;
-  margin-bottom: 0.5rem;
-}
-
 div.recipe-list .sidebar span.field {
   width: 90px;
   text-align: right;

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -51,6 +51,24 @@ function starFormatter() {
   return $('<div />', {'class': 'star', 'html': '&#x269d;'});
 }
 
+function nutritionFormatter(recipe) : $ {
+  const nutrition = $('<td />', {'class': 'nutrition align-top'});
+  if (recipe.nutrition) {
+    nutrition.append($('<div />', {'html': '<strong>Nutrition (per serving)</strong>', 'class': 'heading'}));
+
+    const nutritionFields = ['energy', 'fat', 'carbohydrates', 'fibre', 'protein'];
+    nutritionFields.forEach(field => {
+      if (!recipe.nutrition[field].magnitude) return;
+      const fieldTitle = field.charAt(0).toUpperCase() + field.slice(1);
+      nutrition.append($('<span />', {'html': `<strong>${fieldTitle}</strong>`, 'class': 'field'}));
+      const quantity = renderQuantity(recipe.nutrition[field], false);
+      nutrition.append($('<span />', {'html': `${quantity.magnitude || ''} ${quantity.units || ''}`.trim()}));
+      nutrition.append($('<br />'));
+    });
+  }
+  return nutrition;
+}
+
 function sidebarFormatter(recipe) : $ {
   const duration = Duration.fromObject({minutes: recipe.time}, {locale: resolvedLocale()});
 
@@ -72,20 +90,6 @@ function sidebarFormatter(recipe) : $ {
   sidebar.append($('<span />', {'html': '<strong>Time</strong>', 'class': 'field'}));
   sidebar.append($('<span />', {'text': duration.shiftTo('minutes').toHuman()}));
   sidebar.append($('<br />'));
-
-  if (recipe.nutrition) {
-    sidebar.append($('<div />', {'html': '<strong>Nutrition (per serving)</strong>', 'class': 'heading'}));
-
-    const nutritionFields = ['energy', 'fat', 'carbohydrates', 'fibre', 'protein'];
-    nutritionFields.forEach(field => {
-      if (!recipe.nutrition[field].magnitude) return;
-      const fieldTitle = field.charAt(0).toUpperCase() + field.slice(1);
-      sidebar.append($('<span />', {'html': `<strong>${fieldTitle}</strong>`, 'class': 'field'}));
-      const quantity = renderQuantity(recipe.nutrition[field], false);
-      sidebar.append($('<span />', {'html': `${quantity.magnitude || ''} ${quantity.units || ''}`.trim()}));
-      sidebar.append($('<br />'));
-    });
-  }
 
   const properties = [
     'is_dairy_free',
@@ -127,6 +131,7 @@ function recipeFormatter(value: HTMLElement, recipe: Recipe) : HTMLElement {
   const star = starFormatter();
 
   const row = $('<tr />');
+  row.append(nutritionFormatter(recipe));
   row.append(contentFormatter(recipe));
   row.append(sidebarFormatter(recipe));
 

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -51,22 +51,6 @@ function starFormatter() {
   return $('<div />', {'class': 'star', 'html': '&#x269d;'});
 }
 
-function thumbnailFormatter(recipe) : $ {
-  const container = $('<td />', {'class': 'thumbnail align-top'});
-  const link = $('<a />', {
-    'href': recipe.dst,
-    'ping': `/api/redirect/recipe/${recipe.id}`,
-  });
-  const img = $('<img />', {
-    'class': 'thumbnail',
-    'src': recipe.image_url,
-    'alt': recipe.title,
-  });
-  link.append(img);
-  container.append(link);
-  return container;
-}
-
 function sidebarFormatter(recipe) : $ {
   const duration = Duration.fromObject({minutes: recipe.time}, {locale: resolvedLocale()});
 
@@ -143,7 +127,6 @@ function recipeFormatter(value: HTMLElement, recipe: Recipe) : HTMLElement {
   const star = starFormatter();
 
   const row = $('<tr />');
-  row.append(thumbnailFormatter(recipe));
   row.append(contentFormatter(recipe));
   row.append(sidebarFormatter(recipe));
 

--- a/src/app/views/search.css
+++ b/src/app/views/search.css
@@ -55,8 +55,3 @@
   margin-right: 4px;
   vertical-align: middle;
 }
-
-#search .domain-facets .badge img {
-  margin-right: 4px;
-  height: 16px;
-}

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -106,12 +106,10 @@ function renderDomainFacet(domain: Record<string, string>, state?: boolean) : $ 
   const domainState = state === undefined ? true : state;
   const chip = $('<label />', {'class': 'badge bg-light rounded-pill text-dark'});
   const checkbox = $('<input />', {'type': 'checkbox', 'checked': domainState, 'value': domain.key});
-  const icon = $('<img />', {'src': 'images/domains/' + domain.key + '.ico', 'alt':''});
 
   checkbox.on('change', updateStateDomains);
 
   chip.append(checkbox);
-  chip.append(icon);
   chip.append(document.createTextNode(domain.key));
   return chip;
 }


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
As explained in https://github.com/openculinary/backend/issues/89 - we no longer store recipe thumbnails, and so we can and should make use of that whitespace for other content.  Recipe nutrition seems suitable because it is important and may already be available for some recipes.

### Briefly summarize the changes
1. Remove image thumbnail display from the search results.
1. Add nutritional information -- where provided by each recipe webpage -- in the resulting whitespace.

As a tangentially-related change, we also remove display of recipe website `favicon.ico` images.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Relates to https://github.com/openculinary/backend/issues/89