### PR TITLE
Database: remove the recipe 'directions' table

### DIFF
--- a/src/app/database.ts
+++ b/src/app/database.ts
@@ -24,12 +24,6 @@ export interface Product {
     state: string,
 }
 
-export interface Direction {
-   recipe_id: string,
-   index: number,
-   markup: string,
-}
-
 export interface Recipe {
     id: string,
 
@@ -66,7 +60,6 @@ export interface Stock {
 class Database extends Dexie {
     ingredients: Dexie.Table<Ingredient, [string, string, number]>;  // recipe_id, product_id, index
     products: Dexie.Table<Product, string>;
-    directions: Dexie.Table<Direction, [string, number]>;  // recipe_id, index
     recipes: Dexie.Table<Recipe, string>;
     starred: Dexie.Table<Starred, string>;
     meals: Dexie.Table<Meal, string>;
@@ -75,10 +68,9 @@ class Database extends Dexie {
     constructor() {
       super('RecipeRadar');
 
-      this.version(20200702).stores({
+      this.version(20241219).stores({
         ingredients: '[recipe_id+product_id+index], recipe_id, product_id',
         products: 'id',
-        directions: '[recipe_id+index]',
         recipes: 'id',
         starred: 'recipe_id',
         meals: '$$id, recipe_id',

--- a/src/app/recipeml.spec.ts
+++ b/src/app/recipeml.spec.ts
@@ -1,8 +1,8 @@
 import * as assert from 'assert';
 import { describe, it } from 'mocha';
 
-import { Direction, Ingredient } from './database';
-import { renderIngredientHTML, renderDirectionHTML } from './recipeml';
+import { Ingredient } from './database';
+import { renderIngredientHTML } from './recipeml';
 
 function ingredientHelper(markup, magnitude = null, units = null, state = null) : Ingredient {
   return {
@@ -21,14 +21,6 @@ function ingredientHelper(markup, magnitude = null, units = null, state = null) 
       magnitude: magnitude,
       units: units
     }
-  }
-}
-
-function directionHelper(markup) : Direction {
-  return {
-    recipe_id: null,
-    index: 0,
-    markup: markup
   }
 }
 
@@ -90,26 +82,6 @@ describe('html rendering', function() {
 
     const ingredient = ingredientHelper(recipeML, null, null, 'available');
     const rendered = renderIngredientHTML(ingredient);
-
-    assert.equal(expected, rendered);
-  });
-
-  it('renders simple direction', function() {
-    const recipeML = 'place the <mark class="equipment vessel">casserole dish</mark> in the <mark class="equipment appliance">oven</mark>';
-    const expected = '<li class="direction">place the <span class="equipment">casserole dish</span> in the <span class="equipment">oven</span></li>';
-
-    const direction = directionHelper(recipeML);
-    const rendered = renderDirectionHTML(direction);
-
-    assert.equal(expected, rendered);
-  });
-
-  it('renders directions with actions and equipment', function() {
-    const recipeML = '<mark class="action">heat</mark> the <mark class="equipment appliance">oven</mark> to 200 F';
-    const expected = '<li class="direction"><span class="action">heat</span> the <span class="equipment">oven</span> to 200 F</li>';
-
-    const direction = directionHelper(recipeML);
-    const rendered = renderDirectionHTML(direction);
 
     assert.equal(expected, rendered);
   });

--- a/src/app/recipeml.ts
+++ b/src/app/recipeml.ts
@@ -1,9 +1,9 @@
 import * as $ from 'jquery';
 
-import { Ingredient, Direction } from './database';
+import { Ingredient } from './database';
 import { renderQuantity } from './conversion';
 
-export { renderIngredientHTML, renderDirectionHTML };
+export { renderIngredientHTML };
 
 function renderIngredientHTML(ingredient: Ingredient) : HTMLElement {
     const xml = $.parseXML(`<xml>${ingredient.markup}</xml>`).firstChild;
@@ -17,17 +17,5 @@ function renderIngredientHTML(ingredient: Ingredient) : HTMLElement {
     $(xml).find('ingredient').replaceWith((idx, text) => $('<span />', {'class': 'product', 'text': text}).addClass(ingredient.product.state));
     container.append($('<div />', {'class': 'ingredient', 'html': xml.childNodes}));
 
-    return container.html();
-}
-
-function renderDirectionHTML(direction: Direction) : HTMLElement {
-    const xml = $.parseXML(`<xml>${direction.markup}</xml>`).firstChild;
-    const container = $('<div />');
-
-    $(xml).find('mark[class*=equipment]').replaceWith((idx, text) => $('<span />', {'class': 'equipment', 'text': text}));
-    $(xml).find('mark[class*=action]').replaceWith((idx, text) => $('<span />', {'class': 'action', 'text': text}));
-    const directionHTML = $('<li />', {'class': 'direction', 'html': xml.childNodes});
-
-    container.append(directionHTML);
     return container.html();
 }


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
We have not been displaying recipe direction text in the application since 821b34d9ed0b6c3ab4f4b1e0a19d853c93a5fb09 (2021-03-01), and because we are also removing the recipe directions table from the `backend` database storage (openculinary/backend#91), let's remove it from the client application too.

### Briefly summarize the changes
1. Remove the `directions` table from the database definition, and the corresponding `Direction` TypeScript class.
1. We are using [Dexie v4.0.10](https://github.com/openculinary/frontend/blob/2f17b600ee89c7ca5780c4aa57f99df4490a1936/package.json#L14), so we can use an [in-place version upgrade](https://dexie.org/docs/Tutorial/Design#database-versioning) in this case (no need to retain the existing `20200702` version entry here).

### How have the changes been tested?
1. Testing is pending.

**List any issues that this change relates to**
Resolves #259.

Edit: version fixup and add hyperlink for Dexie version claim.