### PR TITLE
Search results: add handling of the 'equipment search unavailable' refinement

### DIFF
--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -83,6 +83,11 @@ function renderRefinement(refinement: string) : $ {
       'data-i18n': i18nAttr('search:refinement-partial-results')
     });
   }
+  if (refinement == 'equipment_search_unavailable') {
+    return $('<div />', {
+      'data-i18n': i18nAttr('search:equipment-search-unavailable')
+    });
+  }
 }
 
 function triggerSearch() : void {

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -85,7 +85,7 @@ function renderRefinement(refinement: string) : $ {
   }
   if (refinement == 'equipment_search_unavailable') {
     return $('<div />', {
-      'data-i18n': i18nAttr('search:equipment-search-unavailable')
+      'data-i18n': i18nAttr('search:refinement-equipment-search-unavailable')
     });
   }
 }


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
After the `backend` database removes the recipe `directions` text (https://github.com/openculinary/backend/issues/91), it will not be possible in the short-term future to extract and provide `equipment` information (e.g. `oven`, `microwave`, `skewers`, ...) in the database nor search engine index.

We want to communicate this to any existing clients that are using the API, and are preparing a `search:refinement-equipment-search-unavailable` i18n resource string -- a refinement message that will appear above the search results -- to inform affected clients.

This isn't perfect process-wise, because we're likely to release the removal of equipment search functionality entirely from the client soon anyway; so there may be few users who encounter the message.  It does however allow us to deploy the relevant components in a sensible and conflict-free order (client messaging upgrade first, then API upgrade, then (backend content removal and/or frontend functionality removal independently)).

### Briefly summarize the changes
1. Check for and display the `equipment_search_unavailable` search refinement message when it is received from the Search API.
1. Update the `i18n` submodule so that we use a version of the internationalization resource strings with `search:equipment_search_unavailable` included.

### How have the changes been tested?
1. Testing is pending.

**List any issues that this change relates to**
Relates to https://github.com/openculinary/backend/issues/91