### PR TITLE
Remove equipment-search functionality

### DIFF
--- a/src/app/autosuggest.ts
+++ b/src/app/autosuggest.ts
@@ -3,33 +3,6 @@ import select2 from 'select2';
 
 export {};
 
-function bindEquipmentInput(element: string, label: string, placeholder: string) : void {
-  select2 && new select2($(element), {
-    ajax: {
-      url: '/api/autosuggest/equipment',
-      data: params => ({pre: params.term}),
-      processResults: data => ({
-        results: data.map(item => ({
-          id: item.equipment,
-          text: item.equipment,
-          product: item
-        }))
-      })
-    },
-    minimumInputLength: 3,
-    placeholder: placeholder,
-    selectOnClose: true
-  });
-
-  // TODO: Revisit once https://github.com/select2/select2/issues/3744 is handled
-  $(element).next('.select2').find('input[type=search]').attr('aria-label', label);
-
-  // TODO: https://github.com/openculinary/frontend/issues/239 - report upstream?
-  $(element).on('select2:unselect', function(evt) {
-    evt.params.data.element.remove();
-  });
-}
-
 function bindIngredientInput(element: string, label: string, placeholder: string) : void {
   select2 && new select2($(element), {
     ajax: {
@@ -60,7 +33,6 @@ function bindIngredientInput(element: string, label: string, placeholder: string
 $(function() {
   bindIngredientInput('#include', 'Ingredients to include', 'e.g. tomatoes');
   bindIngredientInput('#exclude', 'Ingredients to exclude', 'e.g. mushrooms');
-  bindEquipmentInput('#equipment', 'Kitchen equipment to use', 'e.g. slow cooker');
 
   $(document).on('keyup', '.select2-search__field', function (event) {
     if (event.which == 13) {

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -78,7 +78,6 @@ function loadState() : void {
 
   loadTags('#include', state.include);
   loadTags('#exclude', state.exclude);
-  loadTags('#equipment', state.equipment);
   loadDietaryProperties(state);
 
   $('body > div.container[id]').each(function() {

--- a/src/app/views/search.css
+++ b/src/app/views/search.css
@@ -20,7 +20,6 @@
 
 #search .include + span { color: #70f070; }
 #search .exclude + span { color: #f07070; }
-#search .equipment + span { color: #7070f0; }
 
 #search .dietary-properties ~ ul {
   list-style-type: none;

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -12,7 +12,7 @@ export { renderRecipe, renderSearch };
 
 function pushSearch() : void {
   const state = {'search': null, 'action': 'search'};
-  ['#include', '#exclude', '#equipment'].forEach(function (element) {
+  ['#include', '#exclude'].forEach(function (element) {
     const fragment = element.replace('#', '');
     const data = $(element).val();
     if (data.length > 0) {
@@ -51,12 +51,10 @@ function renderRecipe() : void {
 function renderSearch() : void {
   const ingredientsToInclude = $('#include').val();
   const ingredientsToExclude = $('#exclude').val();
-  const equipmentToInclude = $('#equipment').val();
   const dietaryProperties = $('#search span.dietary-properties + ul :checkbox:checked').map((_, property) => property.id).toArray();
 
   const params = {
     ingredients: ingredientsToInclude.concat(ingredientsToExclude.map(name => `-${name}`)),
-    equipment: equipmentToInclude,
   };
 
   const state = getState();

--- a/src/index.html
+++ b/src/index.html
@@ -66,9 +66,6 @@
               <div class="prompt exclude" data-i18n="[html]search:prompt-exclude"></div>
               <span>&#x229d;</span>
               <select id="exclude" multiple="multiple"></select>
-              <div class="prompt equipment" data-i18n="[html]search:prompt-equipment"></div>
-              <span>&#x2699;</span>
-              <select id="equipment" multiple="multiple"></select>
             </div>
             <div class="col">
               <span class="prompt dietary-properties" data-i18n="[html]search:prompt-dietary-properties"></span>


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Because the Search API will no longer provide query-by-equipment functionality after https://github.com/openculinary/api/pull/125 is deployed, we should remove this functionality from the client application.

~~:warning: Not for merge until after #263 and https://github.com/openculinary/api/pull/125~~ (done)

### Briefly summarize the changes
1. Remove query-by-equipment functionality from the UI and application code.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Relates to https://github.com/openculinary/backend/issues/91

Edit: note that dependencies have been deployed, and that local testing has been performed.