### PR TITLE
HTML template: relocate JavaScript module filtering logic

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -419,7 +419,7 @@
         </div>
       </div>
     </footer>
-<% for (index in htmlWebpackPlugin.files.js.filter(filename => !filename.match(/^html2canvas\./))) { let integrity = htmlWebpackPlugin.files.jsIntegrity[index], src = htmlWebpackPlugin.files.js[index]; %>
+<% for (index in htmlWebpackPlugin.files.js) { if (htmlWebpackPlugin.files.js[index].match(/^html2canvas\./)) continue; let integrity = htmlWebpackPlugin.files.jsIntegrity[index], src = htmlWebpackPlugin.files.js[index]; %>
     <script integrity="<%= integrity %>" crossorigin="anonymous" src="<%= src %>"<% if (!src.match(/^app\./)) { %> async="async"<% } %>></script><% } %>
   </body>
 </html>


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
We seem to be writing a slightly-incorrect set of `.js` `<script>` tags into the `index.html` page during evaluation of the [template](https://github.com/openculinary/frontend/blob/71a1a8cf8ba98880e08fadaea63a030ad5e7a49e/src/index.html).

In particular, something to do with the [`filename` filtering](https://github.com/openculinary/frontend/blob/71a1a8cf8ba98880e08fadaea63a030ad5e7a49e/src/index.html#L422) seems to be problematic; the desired intent is for [configured `webpack` JavaScript modules](https://github.com/openculinary/frontend/blob/71a1a8cf8ba98880e08fadaea63a030ad5e7a49e/webpack.config.js#L16-L21) _except for_ the loaded-on-demand `html2canvas.js` file (or [`html2canvas.min.js` in production](https://github.com/openculinary/frontend/blob/71a1a8cf8ba98880e08fadaea63a030ad5e7a49e/webpack.config.js#L12)).

Instead, `html2canvas` _does_ appear in the evaluated -- and `sw.js` (the Service Worker module) does not.  This could explain why the service worker -- required for a Progressive Web App -- is not available.

### Briefly summarize the changes
1. Instead of applying a `.filter` function on the JavaScript modules loop iterator, retrieve and inspect each filename within individual iterations of the loop.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
May resolve #261.