### PR TITLE
nginx config: apply RFC9239 replacement of MIME type 'application/javascript' with 'text/javascript'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ image: image-create webpack license-check image-finalize
 
 image-create:
 	$(eval container=$(shell buildah from docker.io/library/nginx:alpine))
+	# RFC9239, May 2022: 'text/javascript' replaces 'application/javascript'
+	# https://www.rfc-editor.org/rfc/rfc9239#section-6
+	# NOTE: There is a feature request in nginx for this to become the default
+	# https://trac.nginx.org/nginx/ticket/1407
+	buildah run $(container) -- sed --expression 's#application/javascript#text/javascript#' --in-place /etc/nginx/mime.types
 	buildah copy $(container) 'etc/nginx/conf.d' '/etc/nginx/conf.d'
 	buildah run --network none $(container) -- rm -rf '/usr/share/nginx/html' --
 

--- a/etc/nginx/conf.d/expires.conf
+++ b/etc/nginx/conf.d/expires.conf
@@ -1,5 +1,5 @@
 map $sent_http_content_type $expires {
-    application/javascript 1y;
+    text/javascript 1y;
     image/png 1y;
     image/x-icon 1y;
     text/css 1y;


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Migrates some HTTP MIME type configuration from the `infrastructure` repository, so that it applies equally in both development and production environments.

### Briefly summarize the changes
1. Replace the `application/javascript` MIME type in the `nginx` `mime.types` file with a `text/javascript` MIME type.
1. Adjust the `expires.conf` file correspondingly.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Relates to https://github.com/openculinary/infrastructure/issues/55

Edit: fixup for crossreferenced issue number.