### PR TITLE
Webpack: enable module concatenation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ license-check:
 	$(eval licenses=$(shell jq --raw-output ".dependencies | keys | .[]" "package.json" | grep --file - --line-regexp "public/licenses.txt" | wc --lines))
 	$(eval packages=$(shell jq --raw-output ".dependencies | keys | .[]" "package.json" | wc --lines))
 	@if [ "${licenses}" -ne "${packages}" ]; then echo "error: only ${licenses} of ${packages} top-level dependencies found in licenses.txt"; exit 1; fi;
+	$(eval references=$(shell grep --count '"licenses.txt"' public/index.html))
+	$(eval checksums=$(shell grep --count $(shell openssl dgst -sha512 -binary public/licenses.txt | base64 --wrap 0) public/index.html))
+	@if [ "${references}" -ne "${checksums}" ]; then echo "error: expected ${references} licenses.txt checksums in index.html but found ${checksums}"; exit 1; fi;
 
 image-finalize:
 	buildah copy $(container) 'public' '/usr/share/nginx/html'

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ license-check:
 	$(eval licenses=$(shell jq --raw-output ".dependencies | keys | .[]" "package.json" | grep --file - --line-regexp "public/licenses.txt" | wc --lines))
 	$(eval packages=$(shell jq --raw-output ".dependencies | keys | .[]" "package.json" | wc --lines))
 	@if [ "${licenses}" -ne "${packages}" ]; then echo "error: only ${licenses} of ${packages} top-level dependencies found in licenses.txt"; exit 1; fi;
-	$(eval references=$(shell grep --count '"licenses.txt"' public/index.html))
-	$(eval checksums=$(shell grep --count $(shell openssl dgst -sha512 -binary public/licenses.txt | base64 --wrap 0) public/index.html))
+	$(eval references=$(shell grep --count '"licenses.txt"' "public/index.html"))
+	$(eval checksums=$(shell grep --count $(shell openssl dgst -sha512 -binary "public/licenses.txt" | base64 --wrap 0) "public/index.html"))
 	@if [ "${references}" -ne "${checksums}" ]; then echo "error: expected ${references} licenses.txt checksums in index.html but found ${checksums}"; exit 1; fi;
 
 image-finalize:

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "i18next-conv": "^15.1.1",
         "i18next-scanner": "4.6.0",
         "jsdom": "25.0.1",
-        "license-webpack-plugin": "4.0.2",
         "mocha": "10.8.2",
         "ts-loader": "9.5.1",
         "ts-node": "10.9.2",
@@ -54,6 +53,7 @@
         "typescript-eslint": "8.16.0",
         "webpack": "5.96.1",
         "webpack-cli": "5.1.4",
+        "webpack-license-plugin": "4.5.0",
         "webpack-subresource-integrity": "5.1.0",
         "workbox-webpack-plugin": "7.3.0"
       }
@@ -6597,23 +6597,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/license-webpack-plugin": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/license-webpack-plugin/-/license-webpack-plugin-4.0.2.tgz",
-      "integrity": "sha512-771TFWFD70G1wLTC4oU2Cw4qvtmNrIw+wRvBtn+okgHl7slJVi7zfNcdmqDL72BojM30VNJ2UHylr1o77U37Jw==",
-      "dev": true,
-      "dependencies": {
-        "webpack-sources": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack": {
-          "optional": true
-        },
-        "webpack-sources": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -7045,6 +7028,22 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/needle": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
+      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -7926,6 +7925,12 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "dev": true
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -8175,6 +8180,37 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-expression-validate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-validate/-/spdx-expression-validate-2.0.0.tgz",
+      "integrity": "sha512-b3wydZLM+Tc6CFvaRDBOF9d76oGIHNCLYFeHbftFXUWjnfZWganmDmvtM5sm1cRwJc/VDBMLyGGrsLFd1vOxbg==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
       "dev": true
     },
     "node_modules/stream-composer": {
@@ -9225,6 +9261,37 @@
       "dev": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/webpack-license-plugin": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-license-plugin/-/webpack-license-plugin-4.5.0.tgz",
+      "integrity": "sha512-qtxmKEtbW8evdZE0kkB9Kcy1o0Y6g08e3/HXrsopRwM/eHPKb8aAqrZWFDkDlV/jwPSYfp1eWu+Ek2ju812NYQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "lodash": "^4.17.21",
+        "needle": "^3.2.0",
+        "spdx-expression-validate": "^2.0.0",
+        "webpack-sources": "^3.2.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "webpack": ">=4.0.0 < 6.0.0"
+      }
+    },
+    "node_modules/webpack-license-plugin/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "i18next-conv": "^15.1.1",
     "i18next-scanner": "4.6.0",
     "jsdom": "25.0.1",
-    "license-webpack-plugin": "4.0.2",
+    "webpack-license-plugin": "4.5.0",
     "mocha": "10.8.2",
     "ts-loader": "9.5.1",
     "ts-node": "10.9.2",

--- a/src/RecipeML/package.json
+++ b/src/RecipeML/package.json
@@ -1,4 +1,5 @@
 {
   "name": "RecipeML",
-  "license": "LicenseRef-FormatData-RecipeML"
+  "license": "LicenseRef-FormatData-RecipeML",
+  "version": "1.0"
 }

--- a/src/feedback/package.json
+++ b/src/feedback/package.json
@@ -1,4 +1,5 @@
 {
   "name": "feedback.js",
-  "license": "MIT"
+  "license": "MIT",
+  "version": "N/A"
 }

--- a/src/index.html
+++ b/src/index.html
@@ -391,8 +391,8 @@
               <p>The license to this software is bundled with the application and is also <a integrity="sha512-/VmsC2zX+w/AMx3VBBib2r3ICkFlHUUfRDxxdF593TGHc2D3oWgaHmZsXhQdXR5iMJAS+DGQ8YaCAiFzXu+sWQ==" href="https://github.com/openculinary/frontend/blob/b2bcab413b424d9b6e1a64db16777beccdfb6ba7/LICENSE">available to read online.</a></p>
               <p>Included below are the licenses for the dependencies of this application.</p>
               <!-- TODO: Use webpack build to embed integrity hashes for 'licenses.txt'; see https://github.com/waysact/webpack-subresource-integrity/issues/208 -->
-              <iframe integrity="sha512-+6cx6o7EBi008aQgVnWtwy1ZCZA0pidal0f5Du+Ss0Fj9oDu06jdem6tHkUB3ZWWtasVKqL/HAbFdY7IVc9PAA==" class="container-fluid" src="licenses.txt"></iframe>
-              <p>The license for the packages that this application depends upon are <a integrity="sha512-O1Mh4TtDC6z+cTZsRkE9cTmpxAVcFqffyQ7Ck5vYK84h6b3up0aRePLeiuyHIoxR8MxdGRhP/Gn4uDTUmqjhhQ==" href="licenses.txt">available to read here.</a></p>
+              <iframe integrity="sha512-OiBpoj+pAz1+xEGHjWSgFSDfmzypvkr1oveSJTkUE+CUCGNeUhQq5a1YRVVxcOj+d9QaIPrH/NO56cxBSgtkgA==" class="container-fluid" src="licenses.txt"></iframe>
+              <p>The license for the packages that this application depends upon are <a integrity="sha512-OiBpoj+pAz1+xEGHjWSgFSDfmzypvkr1oveSJTkUE+CUCGNeUhQq5a1YRVVxcOj+d9QaIPrH/NO56cxBSgtkgA==" href="licenses.txt">available to read here.</a></p>
             </div>
           </div>
           <div class="modal-footer">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ function manualLicenseInfo(package) {
       'spdx': 'BSD-2-Clause',
       'detail': 'SEE LICENSE IN https://github.com/kornelski/slip/blob/91c24e460dbadb9e0dc40daf93fd01928bfac94d/package.json#L18'
     }
-  }[package] || {'spdx': '', 'detail': package};
+  }[package];
 }
 
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,9 +3,28 @@ const glob = require('glob');
 
 const { InjectManifest } = require('workbox-webpack-plugin');
 const { SubresourceIntegrityPlugin } = require('webpack-subresource-integrity');
-const LicenseWebpackPlugin = require('license-webpack-plugin').LicenseWebpackPlugin;
+const LicensePlugin = require('webpack-license-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+
+function manualLicenseInfo(package) {
+  return {
+    'jsondiffpatch': {
+      'spdx': 'MIT',
+      'detail': 'SEE LICENSE IN https://github.com/benjamine/jsondiffpatch/blob/a8cde4c666a8a25d09d8f216c7f19397f2e1b569/package.json#L81'
+    },
+    'slipjs': {
+      'spdx': 'BSD-2-Clause',
+      'detail': 'SEE LICENSE IN https://github.com/kornelski/slip/blob/91c24e460dbadb9e0dc40daf93fd01928bfac94d/package.json#L18'
+    }
+  }[package] || {'spdx': '', 'detail': package};
+}
+
+
+function licensesAsText(packages) {
+  return packages.sort(package => package.name.toLower).map(package => `${package.name}\n${package.license}\n${package.licenseText || manualLicenseInfo(package.name)['detail']}`).join('\n\n');
+}
 
 
 module.exports = (_, env) => {
@@ -34,20 +53,16 @@ module.exports = (_, env) => {
       library: '[name]'
     },
     plugins: [
-      new LicenseWebpackPlugin({
-        additionalModules: [
-          {
-            name: 'RecipeML',
-            directory: path.join(__dirname, 'src', 'RecipeML')
-          },
+      new LicensePlugin({
+        additionalFiles: {'licenses.txt': licensesAsText},
+        includePackages: () => [
+          path.resolve(__dirname, 'src/feedback'),
+          path.resolve(__dirname, 'src/RecipeML')
         ],
-        handleMissingLicenseText: (package) => { throw Error(`Could not determine license for ${package}`) },
-        licenseTypeOverrides: {
-          'jsondiffpatch': 'SEE LICENSE IN https://github.com/benjamine/jsondiffpatch/blob/a8cde4c666a8a25d09d8f216c7f19397f2e1b569/package.json#L81',
-          'slipjs': 'SEE LICENSE IN https://github.com/kornelski/slip/blob/91c24e460dbadb9e0dc40daf93fd01928bfac94d/package.json#L18'
+        licenseOverrides: {
+          'jsondiffpatch': manualLicenseInfo('jsondiffpatch')['spdx'],
+          'slipjs': manualLicenseInfo('slipjs')['spdx']
         },
-        outputFilename: 'licenses.txt',
-        perChunkOutput: false
       }),
       new CopyWebpackPlugin({patterns: [
         {
@@ -116,7 +131,6 @@ module.exports = (_, env) => {
     },
     optimization: {
       minimize: true,
-      concatenateModules: false,  // module concatenation, enabled by default for production builds, can potentially confuse license-webpack-plugin
       realContentHash: true,
       sideEffects: true,
       usedExports: true


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Reduce the size of the web application code bundle by enabling [`webpack`](https://github.com/webpack/webpack/)'s [module concatenation](https://webpack.js.org/configuration/optimization/#optimizationconcatenatemodules) option.

To do so, migrate from [`xz64/license-webpack-plugin`](https://github.com/xz64/license-webpack-plugin/) to [`codepunkt/webpack-license-plugin`](https://github.com/codepunkt/webpack-license-plugin/) (GitHub usernames added for disambiguation due to similar-albeit-not-identical repository names).

### Briefly summarize the changes
1. Migrate the license detection dependency.
1. Add a custom license format output function, to retain a near-identical text output format.
1. Remove the `concatenateModules: false` configuration setting that was previously applied.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
N/A