### PR TITLE
Feature: add recipe search result problem reporting

### DIFF
--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -34,6 +34,7 @@ i18next && void i18next.use(BrowserLanguage).use(HTTP).init({
     'footer',
     'meal-planner',
     'navigation',
+    'problem-reports',
     'search',
     'shopping-list',
     'starred-recipes',

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -73,8 +73,6 @@ div.recipe-list .star {
 
 div.recipe-list .report-problem {
   float: left;
-
-  line-height: 1rem;
 }
 
 div.recipe-list .recipe table {

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -74,8 +74,11 @@ div.recipe-list .star {
 div.recipe-list .report-problem {
   float: left;
 
+  line-height: 1rem;
+}
+
+div.recipe-list .report-problem .icon {
   color: red;
-  font-size: 1rem;
   font-weight: bold;
 }
 

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -77,11 +77,6 @@ div.recipe-list .report-problem {
   line-height: 1rem;
 }
 
-div.recipe-list .report-problem .icon {
-  color: red;
-  font-weight: bold;
-}
-
 div.recipe-list .recipe table {
   clear: both;
 }

--- a/src/app/views/components/recipe-list.css
+++ b/src/app/views/components/recipe-list.css
@@ -71,6 +71,14 @@ div.recipe-list .star {
   font-size: 1rem;
 }
 
+div.recipe-list .report-problem {
+  float: left;
+
+  color: red;
+  font-size: 1rem;
+  font-weight: bold;
+}
+
 div.recipe-list .recipe table {
   clear: both;
 }

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -53,9 +53,19 @@ function starFormatter() {
 }
 
 function reportProblemFormatter() {
-  const container = $('<a />', {'class': 'report-problem'});
-  container.append($('<div />', {'class': 'icon', 'html': '&#x26a0;'}));
-  container.append($('<div />', {'data-i18n': i18nAttr('search:result-report-problem')}));
+  const reportButton = $('<button />', {
+    'class': 'btn btn-outline-danger dropdown-toggle',
+    'data-bs-toggle': 'dropdown',
+    'data-i18n': i18nAttr('search:result-report-problem')
+  });
+  const dropdownList = $('<ul />', {'class': 'dropdown-menu'});
+  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'text': 'Please exclude my recipe(s)'})));
+  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'text': 'Link contains unsafe content'})));
+  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'text': 'Offer a correction'})));
+
+  const container = $('<div />', {'class': 'report-problem'});
+  container.append(reportButton);
+  container.append(dropdownList);
   return container;
 }
 
@@ -238,7 +248,7 @@ function bindPostBody(selector: string) : void {
     $(this).find('input.servings').each((_, input) => {
       $(input).on('change', () => { void getRecipe(input).then(updateServings); });
     });
-    $(this).find('a.report-problem').each((_, hyperlink) => {
+    $(this).find('div.report-problem ul.dropdown-menu a').each((_, hyperlink) => {
       $(hyperlink).on('click', () => {
         const reportForm = new bootstrap.Modal('#problem-report-modal');
         reportForm.show();

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -251,7 +251,7 @@ function bindPostBody(selector: string) : void {
     $(this).find('div.report-problem ul.dropdown-menu a').each((_, hyperlink) => {
       $(hyperlink).on('click', () => {
         void getRecipe(hyperlink).then(recipe => {
-          $('#problem-report-modal input[name="recipe_id"]').val(recipe.id);
+          $('#problem-report-modal input[name="recipe-id"]').val(recipe.id);
 
           const reportForm = new bootstrap.Modal('#problem-report-modal');
           reportForm.show();

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -59,9 +59,9 @@ function reportProblemFormatter() {
     'data-i18n': i18nAttr('search:result-report-problem')
   });
   const dropdownList = $('<ul />', {'class': 'dropdown-menu'});
-  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'href': '#removal-request', 'text': 'Please exclude my recipe(s)'})));
-  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'href': '#unsafe-content', 'text': 'Link contains unsafe content'})));
-  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'href': '#correction', 'text': 'Offer a correction'})));
+  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'href': '#removal-request', 'data-i18n': i18nAttr('problem-reports:menu-text-removal-request')})));
+  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'href': '#unsafe-content', 'data-i18n': i18nAttr('problem-reports:menu-text-unsafe-content')})));
+  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'href': '#correction', 'data-i18n': i18nAttr('problem-reports:menu-text-correction')})));
 
   const container = $('<div />', {'class': 'report-problem'});
   container.append(reportButton);

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -51,6 +51,17 @@ function starFormatter() {
   return $('<div />', {'class': 'star', 'html': '&#x269d;'});
 }
 
+function reportProblemFormatter() {
+  const container = $('<a />');
+  container.append($('<div />', {'class': 'report-problem', 'html': '&#x26a0;'}));
+  container.append($('<div />', {'class': 'lh-lg', 'data-i18n': i18nAttr('search:result-report-problem')}));
+
+  container.on('click', () => {
+    console.log("TODO: open problem report dialog");
+  });
+  return container;
+}
+
 function nutritionFormatter(recipe) : $ {
   const nutrition = $('<td />', {'class': 'nutrition align-top'});
   if (recipe.nutrition) {
@@ -141,9 +152,12 @@ function recipeFormatter(value: HTMLElement, recipe: Recipe) : HTMLElement {
   });
   table.append(row);
 
+  const reportProblem = reportProblemFormatter();
+
   container.append(attribution);
   container.append(star);
   container.append(table);
+  container.append(reportProblem);
 
   container.append($('<button />', {
     'class': 'add btn btn-outline-primary add-recipe float-right',

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -250,7 +250,7 @@ function bindPostBody(selector: string) : void {
     });
     $(this).find('div.report-problem ul.dropdown-menu a').each((_, hyperlink) => {
       $(hyperlink).on('click', () => {
-        const recipeId = getRecipe(hyperlink).then(recipe => {
+        void getRecipe(hyperlink).then(recipe => {
           $('#problem-report-modal input[name="recipe_id"]').val(recipe.id);
 
           const reportForm = new bootstrap.Modal('#problem-report-modal');

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -55,10 +55,6 @@ function reportProblemFormatter() {
   const container = $('<a />', {'class': 'report-problem'});
   container.append($('<div />', {'class': 'icon', 'html': '&#x26a0;'}));
   container.append($('<div />', {'data-i18n': i18nAttr('search:result-report-problem')}));
-
-  container.on('click', () => {
-    console.log("TODO: open problem report dialog");
-  });
   return container;
 }
 
@@ -240,6 +236,9 @@ function bindPostBody(selector: string) : void {
 
     $(this).find('input.servings').each((_, input) => {
       $(input).on('change', () => { void getRecipe(input).then(updateServings); });
+    });
+    $(this).find('a.report-problem').each((_, hyperlink) => {
+      $(hyperlink).on('click', () => { console.log("TODO: open problem report dialog"); });
     });
     $(this).find('button.add-recipe').each((_, button) => {
       $(button).on('click', () => { void getRecipe(button).then(addRecipe).then(updateRecipeState); });

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -1,3 +1,4 @@
+import * as bootstrap from 'bootstrap';
 import { Duration } from 'luxon';
 import * as $ from 'jquery';
 import 'tablesaw/dist/stackonly/tablesaw.stackonly.jquery.js';
@@ -238,7 +239,13 @@ function bindPostBody(selector: string) : void {
       $(input).on('change', () => { void getRecipe(input).then(updateServings); });
     });
     $(this).find('a.report-problem').each((_, hyperlink) => {
-      $(hyperlink).on('click', () => { console.log("TODO: open problem report dialog"); });
+      $(hyperlink).on('click', () => {
+        const reportForm = new bootstrap.Modal('#problem-report-modal');
+        reportForm.show();
+
+        const tab = new bootstrap.Tab('#problem-report-modal a[href="#removal-request"]');
+        tab.show();
+      });
     });
     $(this).find('button.add-recipe').each((_, button) => {
       $(button).on('click', () => { void getRecipe(button).then(addRecipe).then(updateRecipeState); });

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -59,9 +59,9 @@ function reportProblemFormatter() {
     'data-i18n': i18nAttr('search:result-report-problem')
   });
   const dropdownList = $('<ul />', {'class': 'dropdown-menu'});
-  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'text': 'Please exclude my recipe(s)'})));
-  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'text': 'Link contains unsafe content'})));
-  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'text': 'Offer a correction'})));
+  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'href': '#removal-request', 'text': 'Please exclude my recipe(s)'})));
+  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'href': '#unsafe-content', 'text': 'Link contains unsafe content'})));
+  dropdownList.append($('<li />').append($('<a />', {'class': 'dropdown-item', 'href': '#correction', 'text': 'Offer a correction'})));
 
   const container = $('<div />', {'class': 'report-problem'});
   container.append(reportButton);
@@ -253,7 +253,7 @@ function bindPostBody(selector: string) : void {
         const reportForm = new bootstrap.Modal('#problem-report-modal');
         reportForm.show();
 
-        const tab = new bootstrap.Tab('#problem-report-modal a[href="#removal-request"]');
+        const tab = new bootstrap.Tab(`#problem-report-modal a[href="${hyperlink.attributes.href.value}"]`);
         tab.show();
       });
     });

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -52,9 +52,9 @@ function starFormatter() {
 }
 
 function reportProblemFormatter() {
-  const container = $('<a />');
-  container.append($('<div />', {'class': 'report-problem', 'html': '&#x26a0;'}));
-  container.append($('<div />', {'class': 'lh-lg', 'data-i18n': i18nAttr('search:result-report-problem')}));
+  const container = $('<a />', {'class': 'report-problem'});
+  container.append($('<div />', {'class': 'icon', 'html': '&#x26a0;'}));
+  container.append($('<div />', {'data-i18n': i18nAttr('search:result-report-problem')}));
 
   container.on('click', () => {
     console.log("TODO: open problem report dialog");

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -164,12 +164,12 @@ function recipeFormatter(value: HTMLElement, recipe: Recipe) : HTMLElement {
   container.append(attribution);
   container.append(star);
   container.append(table);
-  container.append(reportProblem);
 
   container.append($('<button />', {
     'class': 'add btn btn-outline-primary add-recipe float-right',
     'data-i18n': i18nAttr('search:result-add-recipe')
   }));
+  container.append(reportProblem);
 
   return container.html();
 }

--- a/src/app/views/components/recipe-list.ts
+++ b/src/app/views/components/recipe-list.ts
@@ -250,11 +250,15 @@ function bindPostBody(selector: string) : void {
     });
     $(this).find('div.report-problem ul.dropdown-menu a').each((_, hyperlink) => {
       $(hyperlink).on('click', () => {
-        const reportForm = new bootstrap.Modal('#problem-report-modal');
-        reportForm.show();
+        const recipeId = getRecipe(hyperlink).then(recipe => {
+          $('#problem-report-modal input[name="recipe_id"]').val(recipe.id);
 
-        const tab = new bootstrap.Tab(`#problem-report-modal a[href="${hyperlink.attributes.href.value}"]`);
-        tab.show();
+          const reportForm = new bootstrap.Modal('#problem-report-modal');
+          reportForm.show();
+
+          const tab = new bootstrap.Tab(`#problem-report-modal a[href="${hyperlink.attributes.href.value}"]`);
+          tab.show();
+        });
       });
     });
     $(this).find('button.add-recipe').each((_, button) => {

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -31,10 +31,10 @@ function pushSearch() : void {
 }
 $('#search form button').on('click', pushSearch);
 
-function sendProblemReport() : void {
-  $.post("/api/recipes/report", $(this).parent('form').serialize());
+function sendProblemReport() : boolean {
+  $.post("/api/recipes/report", $(this).serialize());
+  return false;
 }
-$('#problem-report-modal form button').on('click', sendProblemReport);
 
 function renderRecipe() : void {
   const state = getState();
@@ -230,5 +230,5 @@ $(function() {
   bindLoadEvent('#search', () => scrollToResults('#search', 50));
 
   $('#search form').on('submit', () => false);
-  $('#problem-report-modal form').on('submit', () => false);
+  $('#problem-report-modal form').on('submit', sendProblemReport);
 });

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -1,3 +1,4 @@
+import * as bootstrap from 'bootstrap';
 import * as $ from 'jquery';
 import * as debounce from 'debounce';
 
@@ -32,7 +33,32 @@ function pushSearch() : void {
 $('#search form button').on('click', pushSearch);
 
 function sendProblemReport() : boolean {
-  $.post("/api/recipes/report", $(this).serialize());
+  $.post("/api/recipes/report", $(this).serialize())
+    .always(() => {
+      $('#problem-report-modal').modal('toggle');
+    })
+    .done(() => {
+      const modal = $('#problem-report-status-modal');
+      const title = modal.find('.modal-title').empty();
+      const body = modal.find('.modal-body').empty();
+      title.append($('<h5 />', {'data-i18n': i18nAttr('problem-reports:report-status-success-title')}));
+      body.append($('<p />', {'data-i18n': i18nAttr('problem-reports:report-status-success-message')}));
+      modal.localize();
+
+      const statusModal = new bootstrap.Modal('#problem-report-status-modal');
+      statusModal.show();
+    })
+    .fail(() => {
+      const modal = $('#problem-report-status-modal');
+      const title = modal.find('.modal-title').empty();
+      const body = modal.find('.modal-body').empty();
+      title.append($('<h5 />', {'data-i18n': i18nAttr('problem-reports:report-status-failure-title')}));
+      body.append($('<p />', {'data-i18n': i18nAttr('problem-reports:report-status-failure-message')}));
+      modal.localize();
+
+      const statusModal = new bootstrap.Modal('#problem-report-status-modal');
+      statusModal.show();
+    });
   return false;
 }
 

--- a/src/app/views/search.ts
+++ b/src/app/views/search.ts
@@ -31,6 +31,11 @@ function pushSearch() : void {
 }
 $('#search form button').on('click', pushSearch);
 
+function sendProblemReport() : void {
+  $.post("/api/recipes/report", $(this).parent('form').serialize());
+}
+$('#problem-report-modal form button').on('click', sendProblemReport);
+
 function renderRecipe() : void {
   const state = getState();
   void getRecipeById(state.id).then(recipe => {
@@ -225,4 +230,5 @@ $(function() {
   bindLoadEvent('#search', () => scrollToResults('#search', 50));
 
   $('#search form').on('submit', () => false);
+  $('#problem-report-modal form').on('submit', () => false);
 });

--- a/src/index.html
+++ b/src/index.html
@@ -418,20 +418,26 @@
         <div class="tab-pane" id="removal-request" role="tabpanel">
           <form class="card">
             <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
+            <input id="report_type" type="hidden" value="removal_request" />
             <input id="content-owner-email" type="text" />
             <input id="content-reuse-policy" type="text" />
             <input id="content-noindex-directive" type="checkbox" />
+            <button class="btn btn-primary" type="submit"></button>
           </form>
         </div>
         <div class="tab-pane" id="unsafe-content" role="tabpanel">
           <form class="card">
+            <input id="report_type" type="hidden" value="unsafe_content" />
+            <button class="btn btn-primary" type="submit"></button>
           </form>
         </div>
         <div class="tab-pane" id="correction" role="tabpanel">
           <form class="card">
             <!-- require: description of expected-content as compared to found-content -->
+            <input id="report_type" type="hidden" value="correction" />
             <input id="content-expected" type="text" />
             <input id="content-found" type="text" />
+            <button class="btn btn-primary" type="submit"></button>
           </form>
         </div>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -400,6 +400,26 @@
       </div>
     </div>
 
+    <div id="problem-report-modal" class="modal" role="dialog">
+      <div class="modal-header">
+        <ul class="nav nav-pills" role="tablist">
+          <li class="nav-item">
+            <a class="nav-link active" href="#removal-request" data-bs-toggle="tab" role="tab">Removal Request</a>
+          </li>
+        </ul>
+      </div>
+      <div class="modal-body tab-content">
+        <div class="tab-pane" id="removal-request" role="tabpanel">
+          <form class="card">
+            <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
+            <input id="content-owner-email" type="text" />
+            <input id="content-reuse-policy" type="text" />
+            <input id="content-noindex-directive" type="checkbox" />
+          </form>
+        </div>
+      </div>
+    </div>
+
     <footer>
       <div class="container">
         <div class="row justify-content-evenly">

--- a/src/index.html
+++ b/src/index.html
@@ -421,8 +421,8 @@
             <div class="tab-pane active" id="removal-request" role="tabpanel">
               <form>
                 <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
-                <input name="recipe_id" type="hidden" required="required" />
-                <input name="report_type" type="hidden" value="removal-request" />
+                <input name="recipe-id" type="hidden" required="required" />
+                <input name="report-type" type="hidden" value="removal-request" />
                 <div class="mb-3 form-floating">
                   <input class="form-control" id="content-owner-email" name="content-owner-email" type="email" placeholder="email@recipes.test" />
                   <label for="content-owner-email" data-i18n="problem-reports:content-owner-email-label"></label>
@@ -440,16 +440,16 @@
             </div>
             <div class="tab-pane" id="unsafe-content" role="tabpanel">
               <form>
-                <input name="recipe_id" type="hidden" required="required" />
-                <input name="report_type" type="hidden" value="unsafe-content" />
+                <input name="recipe-id" type="hidden" required="required" />
+                <input name="report-type" type="hidden" value="unsafe-content" />
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-unsafe-content-notification"></button>
               </form>
             </div>
             <div class="tab-pane" id="correction" role="tabpanel">
               <form>
                 <!-- require: description of expected-content as compared to found-content -->
-                <input name="recipe_id" type="hidden" required="required" />
-                <input name="report_type" type="hidden" value="correction" />
+                <input name="recipe-id" type="hidden" required="required" />
+                <input name="report-type" type="hidden" value="correction" />
                 <div class="mb-3 form-floating">
                   <input class="form-control" id="content-expected" name="content-expected" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-expected-content" required="required" />
                   <label for="content-expected" data-i18n="problem-reports:content-expected-label"></label>

--- a/src/index.html
+++ b/src/index.html
@@ -415,6 +415,7 @@
                 <a class="nav-link" href="#correction" data-bs-toggle="tab" role="tab">Correction</a>
               </li>
             </ul>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
           </div>
           <div class="modal-body tab-content">
             <div class="tab-pane" id="removal-request" role="tabpanel">

--- a/src/index.html
+++ b/src/index.html
@@ -429,7 +429,7 @@
                 </div>
                 <div class="form-group">
                   <label for="content-reuse-policy" data-i18n="problem-reports:content-reuse-policy-label"></label>
-                  <input class="form-control" id="content-reuse-policy" name="content-reuse-policy" type="text" placeholder="https://recipes.test/content-reuse-policy.html" />
+                  <input class="form-control" id="content-reuse-policy" name="content-reuse-policy" type="url" placeholder="https://recipes.test/content-reuse-policy.html" />
                 </div>
                 <div class="form-check">
                   <label for="content-noindex-directive" data-i18n="problem-reports:content-noindex-directive-label"></label>

--- a/src/index.html
+++ b/src/index.html
@@ -419,7 +419,7 @@
           </div>
           <div class="modal-body tab-content">
             <div class="tab-pane active" id="removal-request" role="tabpanel">
-              <form class="card" method="POST" action="/api/recipes/report">
+              <form method="POST" action="/api/recipes/report">
                 <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
                 <input name="recipe_id" type="hidden" />
                 <input name="report_type" type="hidden" value="removal_request" />
@@ -439,14 +439,14 @@
               </form>
             </div>
             <div class="tab-pane" id="unsafe-content" role="tabpanel">
-              <form class="card" method="POST" action="/api/recipes/report">
+              <form method="POST" action="/api/recipes/report">
                 <input name="recipe_id" type="hidden" />
                 <input name="report_type" type="hidden" value="unsafe_content" />
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-unsafe-content-notification"></button>
               </form>
             </div>
             <div class="tab-pane" id="correction" role="tabpanel">
-              <form class="card" method="POST" action="/api/recipes/report">
+              <form method="POST" action="/api/recipes/report">
                 <!-- require: description of expected-content as compared to found-content -->
                 <input name="recipe_id" type="hidden" />
                 <input name="report_type" type="hidden" value="correction" />

--- a/src/index.html
+++ b/src/index.html
@@ -401,7 +401,7 @@
     </div>
 
     <div id="problem-report-modal" class="modal" role="dialog">
-      <div class="modal-dialog">
+      <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
           <div class="modal-header">
             <ul class="nav nav-pills" role="tablist">

--- a/src/index.html
+++ b/src/index.html
@@ -421,7 +421,7 @@
             <div class="tab-pane active" id="removal-request" role="tabpanel">
               <form method="POST" action="/api/recipes/report">
                 <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
-                <input name="recipe_id" type="hidden" />
+                <input name="recipe_id" type="hidden" required="required" />
                 <input name="report_type" type="hidden" value="removal_request" />
                 <div class="mb-3 form-floating">
                   <input class="form-control" id="content-owner-email" name="content-owner-email" type="email" placeholder="email@recipes.test" />
@@ -440,7 +440,7 @@
             </div>
             <div class="tab-pane" id="unsafe-content" role="tabpanel">
               <form method="POST" action="/api/recipes/report">
-                <input name="recipe_id" type="hidden" />
+                <input name="recipe_id" type="hidden" required="required" />
                 <input name="report_type" type="hidden" value="unsafe_content" />
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-unsafe-content-notification"></button>
               </form>
@@ -448,14 +448,14 @@
             <div class="tab-pane" id="correction" role="tabpanel">
               <form method="POST" action="/api/recipes/report">
                 <!-- require: description of expected-content as compared to found-content -->
-                <input name="recipe_id" type="hidden" />
+                <input name="recipe_id" type="hidden" required="required" />
                 <input name="report_type" type="hidden" value="correction" />
                 <div class="mb-3 form-floating">
-                  <input class="form-control" id="content-expected" name="content-expected" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-expected-content" />
+                  <input class="form-control" id="content-expected" name="content-expected" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-expected-content" required="required" />
                   <label for="content-expected" data-i18n="problem-reports:content-expected-label"></label>
                 </div>
                 <div class="mb-3 form-floating">
-                  <input class="form-control" id="content-found" name="content-found" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-found-content" />
+                  <input class="form-control" id="content-found" name="content-found" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-found-content" required="required" />
                   <label for="content-found" data-i18n="problem-reports:content-found-label"></label>
                 </div>
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-correction"></button>

--- a/src/index.html
+++ b/src/index.html
@@ -419,7 +419,7 @@
           </div>
           <div class="modal-body tab-content">
             <div class="tab-pane active" id="removal-request" role="tabpanel">
-              <form method="POST" action="/api/recipes/report">
+              <form>
                 <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
                 <input name="recipe_id" type="hidden" required="required" />
                 <input name="report_type" type="hidden" value="removal_request" />
@@ -439,14 +439,14 @@
               </form>
             </div>
             <div class="tab-pane" id="unsafe-content" role="tabpanel">
-              <form method="POST" action="/api/recipes/report">
+              <form>
                 <input name="recipe_id" type="hidden" required="required" />
                 <input name="report_type" type="hidden" value="unsafe_content" />
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-unsafe-content-notification"></button>
               </form>
             </div>
             <div class="tab-pane" id="correction" role="tabpanel">
-              <form method="POST" action="/api/recipes/report">
+              <form>
                 <!-- require: description of expected-content as compared to found-content -->
                 <input name="recipe_id" type="hidden" required="required" />
                 <input name="report_type" type="hidden" value="correction" />

--- a/src/index.html
+++ b/src/index.html
@@ -419,27 +419,30 @@
           </div>
           <div class="modal-body tab-content">
             <div class="tab-pane active" id="removal-request" role="tabpanel">
-              <form class="card">
+              <form class="card" method="POST" action="/api/recipes/report">
                 <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
-                <input id="report_type" type="hidden" value="removal_request" />
-                <input id="content-owner-email" type="text" placeholder="email@recipes.test" />
-                <input id="content-reuse-policy" type="text" placeholder="https://recipes.test/content-reuse-policy.html" />
-                <input id="content-noindex-directive" type="checkbox" />
+                <input name="recipe_id" type="hidden" />
+                <input name="report_type" type="hidden" value="removal_request" />
+                <input name="content-owner-email" type="text" placeholder="email@recipes.test" />
+                <input name="content-reuse-policy" type="text" placeholder="https://recipes.test/content-reuse-policy.html" />
+                <input name="content-noindex-directive" type="checkbox" />
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-removal-request"></button>
               </form>
             </div>
             <div class="tab-pane" id="unsafe-content" role="tabpanel">
-              <form class="card">
-                <input id="report_type" type="hidden" value="unsafe_content" />
+              <form class="card" method="POST" action="/api/recipes/report">
+                <input name="recipe_id" type="hidden" />
+                <input name="report_type" type="hidden" value="unsafe_content" />
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-unsafe-content-notification"></button>
               </form>
             </div>
             <div class="tab-pane" id="correction" role="tabpanel">
-              <form class="card">
+              <form class="card" method="POST" action="/api/recipes/report">
                 <!-- require: description of expected-content as compared to found-content -->
-                <input id="report_type" type="hidden" value="correction" />
-                <input id="content-expected" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-expected-content" />
-                <input id="content-found" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-found-content" />
+                <input name="recipe_id" type="hidden" />
+                <input name="report_type" type="hidden" value="correction" />
+                <input name="content-expected" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-expected-content" />
+                <input name="content-found" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-found-content" />
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-correction"></button>
               </form>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -466,6 +466,18 @@
       </div>
     </div>
 
+    <div id="problem-report-status-modal" class="modal" role="dialog">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <div class="modal-title"></div>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body"></div>
+        </div>
+      </div>
+    </div>
+
     <footer>
       <div class="container">
         <div class="row justify-content-evenly">

--- a/src/index.html
+++ b/src/index.html
@@ -406,6 +406,12 @@
           <li class="nav-item">
             <a class="nav-link active" href="#removal-request" data-bs-toggle="tab" role="tab">Removal Request</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#unsafe-content" data-bs-toggle="tab" role="tab">Unsafe Content</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#correction" data-bs-toggle="tab" role="tab">Correction</a>
+          </li>
         </ul>
       </div>
       <div class="modal-body tab-content">
@@ -415,6 +421,17 @@
             <input id="content-owner-email" type="text" />
             <input id="content-reuse-policy" type="text" />
             <input id="content-noindex-directive" type="checkbox" />
+          </form>
+        </div>
+        <div class="tab-pane" id="unsafe-content" role="tabpanel">
+          <form class="card">
+          </form>
+        </div>
+        <div class="tab-pane" id="correction" role="tabpanel">
+          <form class="card">
+            <!-- require: description of expected-content as compared to found-content -->
+            <input id="content-expected" type="text" />
+            <input id="content-found" type="text" />
           </form>
         </div>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -418,7 +418,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
           </div>
           <div class="modal-body tab-content">
-            <div class="tab-pane" id="removal-request" role="tabpanel">
+            <div class="tab-pane active" id="removal-request" role="tabpanel">
               <form class="card">
                 <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
                 <input id="report_type" type="hidden" value="removal_request" />

--- a/src/index.html
+++ b/src/index.html
@@ -423,9 +423,12 @@
                 <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
                 <input name="recipe_id" type="hidden" />
                 <input name="report_type" type="hidden" value="removal_request" />
-                <input name="content-owner-email" type="text" placeholder="email@recipes.test" />
-                <input name="content-reuse-policy" type="text" placeholder="https://recipes.test/content-reuse-policy.html" />
-                <input name="content-noindex-directive" type="checkbox" />
+                <label for="content-owner-email" data-i18n="problem-reports:content-owner-email-label"></label>
+                <input id="content-owner-email" name="content-owner-email" type="text" placeholder="email@recipes.test" />
+                <label for="content-reuse-policy" data-i18n="problem-reports:content-reuse-policy-label"></label>
+                <input id="content-reuse-policy" name="content-reuse-policy" type="text" placeholder="https://recipes.test/content-reuse-policy.html" />
+                <label for="content-noindex-directive" data-i18n="problem-reports:content-noindex-directive-label"></label>
+                <input id="content-noindex-directive" name="content-noindex-directive" type="checkbox" />
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-removal-request"></button>
               </form>
             </div>
@@ -441,8 +444,10 @@
                 <!-- require: description of expected-content as compared to found-content -->
                 <input name="recipe_id" type="hidden" />
                 <input name="report_type" type="hidden" value="correction" />
-                <input name="content-expected" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-expected-content" />
-                <input name="content-found" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-found-content" />
+                <label for="content-expected" data-i18n="problem-reports:content-expected-label"></label>
+                <input id="content-expected" name="content-expected" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-expected-content" />
+                <label for="content-found" data-i18n="problem-reports:content-found-label"></label>
+                <input id="content-found" name="content-found" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-found-content" />
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-correction"></button>
               </form>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -401,44 +401,48 @@
     </div>
 
     <div id="problem-report-modal" class="modal" role="dialog">
-      <div class="modal-header">
-        <ul class="nav nav-pills" role="tablist">
-          <li class="nav-item">
-            <a class="nav-link active" href="#removal-request" data-bs-toggle="tab" role="tab">Removal Request</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#unsafe-content" data-bs-toggle="tab" role="tab">Unsafe Content</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#correction" data-bs-toggle="tab" role="tab">Correction</a>
-          </li>
-        </ul>
-      </div>
-      <div class="modal-body tab-content">
-        <div class="tab-pane" id="removal-request" role="tabpanel">
-          <form class="card">
-            <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
-            <input id="report_type" type="hidden" value="removal_request" />
-            <input id="content-owner-email" type="text" />
-            <input id="content-reuse-policy" type="text" />
-            <input id="content-noindex-directive" type="checkbox" />
-            <button class="btn btn-primary" type="submit"></button>
-          </form>
-        </div>
-        <div class="tab-pane" id="unsafe-content" role="tabpanel">
-          <form class="card">
-            <input id="report_type" type="hidden" value="unsafe_content" />
-            <button class="btn btn-primary" type="submit"></button>
-          </form>
-        </div>
-        <div class="tab-pane" id="correction" role="tabpanel">
-          <form class="card">
-            <!-- require: description of expected-content as compared to found-content -->
-            <input id="report_type" type="hidden" value="correction" />
-            <input id="content-expected" type="text" />
-            <input id="content-found" type="text" />
-            <button class="btn btn-primary" type="submit"></button>
-          </form>
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <ul class="nav nav-pills" role="tablist">
+              <li class="nav-item">
+                <a class="nav-link active" href="#removal-request" data-bs-toggle="tab" role="tab">Removal Request</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="#unsafe-content" data-bs-toggle="tab" role="tab">Unsafe Content</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="#correction" data-bs-toggle="tab" role="tab">Correction</a>
+              </li>
+            </ul>
+          </div>
+          <div class="modal-body tab-content">
+            <div class="tab-pane" id="removal-request" role="tabpanel">
+              <form class="card">
+                <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
+                <input id="report_type" type="hidden" value="removal_request" />
+                <input id="content-owner-email" type="text" />
+                <input id="content-reuse-policy" type="text" />
+                <input id="content-noindex-directive" type="checkbox" />
+                <button class="btn btn-primary" type="submit"></button>
+              </form>
+            </div>
+            <div class="tab-pane" id="unsafe-content" role="tabpanel">
+              <form class="card">
+                <input id="report_type" type="hidden" value="unsafe_content" />
+                <button class="btn btn-primary" type="submit"></button>
+              </form>
+            </div>
+            <div class="tab-pane" id="correction" role="tabpanel">
+              <form class="card">
+                <!-- require: description of expected-content as compared to found-content -->
+                <input id="report_type" type="hidden" value="correction" />
+                <input id="content-expected" type="text" />
+                <input id="content-found" type="text" />
+                <button class="btn btn-primary" type="submit"></button>
+              </form>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -425,7 +425,7 @@
                 <input name="report_type" type="hidden" value="removal_request" />
                 <div class="form-group">
                   <label for="content-owner-email" data-i18n="problem-reports:content-owner-email-label"></label>
-                  <input class="form-control" id="content-owner-email" name="content-owner-email" type="text" placeholder="email@recipes.test" />
+                  <input class="form-control" id="content-owner-email" name="content-owner-email" type="email" placeholder="email@recipes.test" />
                 </div>
                 <div class="form-group">
                   <label for="content-reuse-policy" data-i18n="problem-reports:content-reuse-policy-label"></label>

--- a/src/index.html
+++ b/src/index.html
@@ -422,7 +422,7 @@
               <form>
                 <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
                 <input name="recipe_id" type="hidden" required="required" />
-                <input name="report_type" type="hidden" value="removal_request" />
+                <input name="report_type" type="hidden" value="removal-request" />
                 <div class="mb-3 form-floating">
                   <input class="form-control" id="content-owner-email" name="content-owner-email" type="email" placeholder="email@recipes.test" />
                   <label for="content-owner-email" data-i18n="problem-reports:content-owner-email-label"></label>
@@ -441,7 +441,7 @@
             <div class="tab-pane" id="unsafe-content" role="tabpanel">
               <form>
                 <input name="recipe_id" type="hidden" required="required" />
-                <input name="report_type" type="hidden" value="unsafe_content" />
+                <input name="report_type" type="hidden" value="unsafe-content" />
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-unsafe-content-notification"></button>
               </form>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -401,7 +401,7 @@
     </div>
 
     <div id="problem-report-modal" class="modal" role="dialog">
-      <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-dialog">
         <div class="modal-content">
           <div class="modal-header">
             <ul class="nav nav-pills" role="tablist">

--- a/src/index.html
+++ b/src/index.html
@@ -423,12 +423,18 @@
                 <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
                 <input name="recipe_id" type="hidden" />
                 <input name="report_type" type="hidden" value="removal_request" />
-                <label for="content-owner-email" data-i18n="problem-reports:content-owner-email-label"></label>
-                <input id="content-owner-email" name="content-owner-email" type="text" placeholder="email@recipes.test" />
-                <label for="content-reuse-policy" data-i18n="problem-reports:content-reuse-policy-label"></label>
-                <input id="content-reuse-policy" name="content-reuse-policy" type="text" placeholder="https://recipes.test/content-reuse-policy.html" />
-                <label for="content-noindex-directive" data-i18n="problem-reports:content-noindex-directive-label"></label>
-                <input id="content-noindex-directive" name="content-noindex-directive" type="checkbox" />
+                <div class="form-group">
+                  <label for="content-owner-email" data-i18n="problem-reports:content-owner-email-label"></label>
+                  <input class="form-control" id="content-owner-email" name="content-owner-email" type="text" placeholder="email@recipes.test" />
+                </div>
+                <div class="form-group">
+                  <label for="content-reuse-policy" data-i18n="problem-reports:content-reuse-policy-label"></label>
+                  <input class="form-control" id="content-reuse-policy" name="content-reuse-policy" type="text" placeholder="https://recipes.test/content-reuse-policy.html" />
+                </div>
+                <div class="form-check">
+                  <label for="content-noindex-directive" data-i18n="problem-reports:content-noindex-directive-label"></label>
+                  <input class="form-check-input" id="content-noindex-directive" name="content-noindex-directive" type="checkbox" />
+                </div>
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-removal-request"></button>
               </form>
             </div>
@@ -444,10 +450,14 @@
                 <!-- require: description of expected-content as compared to found-content -->
                 <input name="recipe_id" type="hidden" />
                 <input name="report_type" type="hidden" value="correction" />
-                <label for="content-expected" data-i18n="problem-reports:content-expected-label"></label>
-                <input id="content-expected" name="content-expected" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-expected-content" />
-                <label for="content-found" data-i18n="problem-reports:content-found-label"></label>
-                <input id="content-found" name="content-found" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-found-content" />
+                <div class="form-group">
+                  <label for="content-expected" data-i18n="problem-reports:content-expected-label"></label>
+                  <input class="form-control" id="content-expected" name="content-expected" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-expected-content" />
+                </div>
+                <div class="form-group">
+                  <label for="content-found" data-i18n="problem-reports:content-found-label"></label>
+                  <input class="form-control" id="content-found" name="content-found" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-found-content" />
+                </div>
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-correction"></button>
               </form>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -423,15 +423,15 @@
                 <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
                 <input name="recipe_id" type="hidden" />
                 <input name="report_type" type="hidden" value="removal_request" />
-                <div class="form-floating">
+                <div class="mb-3 form-floating">
                   <input class="form-control" id="content-owner-email" name="content-owner-email" type="email" placeholder="email@recipes.test" />
                   <label for="content-owner-email" data-i18n="problem-reports:content-owner-email-label"></label>
                 </div>
-                <div class="form-floating">
+                <div class="mb-3 form-floating">
                   <input class="form-control" id="content-reuse-policy" name="content-reuse-policy" type="url" placeholder="https://recipes.test/content-reuse-policy.html" />
                   <label for="content-reuse-policy" data-i18n="problem-reports:content-reuse-policy-label"></label>
                 </div>
-                <div class="form-check">
+                <div class="mb-3 form-check">
                   <input class="form-check-input" id="content-noindex-directive" name="content-noindex-directive" type="checkbox" />
                   <label for="content-noindex-directive" data-i18n="problem-reports:content-noindex-directive-label"></label>
                 </div>
@@ -450,11 +450,11 @@
                 <!-- require: description of expected-content as compared to found-content -->
                 <input name="recipe_id" type="hidden" />
                 <input name="report_type" type="hidden" value="correction" />
-                <div class="form-floating">
+                <div class="mb-3 form-floating">
                   <input class="form-control" id="content-expected" name="content-expected" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-expected-content" />
                   <label for="content-expected" data-i18n="problem-reports:content-expected-label"></label>
                 </div>
-                <div class="form-floating">
+                <div class="mb-3 form-floating">
                   <input class="form-control" id="content-found" name="content-found" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-found-content" />
                   <label for="content-found" data-i18n="problem-reports:content-found-label"></label>
                 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -406,13 +406,13 @@
           <div class="modal-header">
             <ul class="nav nav-pills" role="tablist">
               <li class="nav-item">
-                <a class="nav-link active" href="#removal-request" data-bs-toggle="tab" role="tab">Removal Request</a>
+                <a class="nav-link active" href="#removal-request" data-bs-toggle="tab" role="tab" data-i18n="problem-reports:nav-text-removal-request"></a>
               </li>
               <li class="nav-item">
-                <a class="nav-link" href="#unsafe-content" data-bs-toggle="tab" role="tab">Unsafe Content</a>
+                <a class="nav-link" href="#unsafe-content" data-bs-toggle="tab" role="tab" data-i18n="problem-reports:nav-text-unsafe-content-notification"></a>
               </li>
               <li class="nav-item">
-                <a class="nav-link" href="#correction" data-bs-toggle="tab" role="tab">Correction</a>
+                <a class="nav-link" href="#correction" data-bs-toggle="tab" role="tab" data-i18n="problem-reports:nav-text-correction"></a>
               </li>
             </ul>
             <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
@@ -425,22 +425,22 @@
                 <input id="content-owner-email" type="text" placeholder="email@recipes.test" />
                 <input id="content-reuse-policy" type="text" placeholder="https://recipes.test/content-reuse-policy.html" />
                 <input id="content-noindex-directive" type="checkbox" />
-                <button class="btn btn-primary" type="submit">Send request</button>
+                <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-removal-request"></button>
               </form>
             </div>
             <div class="tab-pane" id="unsafe-content" role="tabpanel">
               <form class="card">
                 <input id="report_type" type="hidden" value="unsafe_content" />
-                <button class="btn btn-primary" type="submit">Send notification</button>
+                <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-unsafe-content-notification"></button>
               </form>
             </div>
             <div class="tab-pane" id="correction" role="tabpanel">
               <form class="card">
                 <!-- require: description of expected-content as compared to found-content -->
                 <input id="report_type" type="hidden" value="correction" />
-                <input id="content-expected" type="text" placeholder="Expected: three medium onions" />
-                <input id="content-found" type="text" placeholder="Found: one small onion" />
-                <button class="btn btn-primary" type="submit">Send correction</button>
+                <input id="content-expected" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-expected-content" />
+                <input id="content-found" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-found-content" />
+                <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-correction"></button>
               </form>
             </div>
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -420,7 +420,6 @@
           <div class="modal-body tab-content">
             <div class="tab-pane active" id="removal-request" role="tabpanel">
               <form>
-                <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
                 <input name="recipe-id" type="hidden" required="required" />
                 <input name="report-type" type="hidden" value="removal-request" />
                 <div class="mb-3 form-floating">
@@ -447,7 +446,6 @@
             </div>
             <div class="tab-pane" id="correction" role="tabpanel">
               <form>
-                <!-- require: description of expected-content as compared to found-content -->
                 <input name="recipe-id" type="hidden" required="required" />
                 <input name="report-type" type="hidden" value="correction" />
                 <div class="mb-3 form-floating">

--- a/src/index.html
+++ b/src/index.html
@@ -422,25 +422,25 @@
               <form class="card">
                 <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
                 <input id="report_type" type="hidden" value="removal_request" />
-                <input id="content-owner-email" type="text" />
-                <input id="content-reuse-policy" type="text" />
+                <input id="content-owner-email" type="text" placeholder="email@recipes.test" />
+                <input id="content-reuse-policy" type="text" placeholder="https://recipes.test/content-reuse-policy.html" />
                 <input id="content-noindex-directive" type="checkbox" />
-                <button class="btn btn-primary" type="submit"></button>
+                <button class="btn btn-primary" type="submit">Send request</button>
               </form>
             </div>
             <div class="tab-pane" id="unsafe-content" role="tabpanel">
               <form class="card">
                 <input id="report_type" type="hidden" value="unsafe_content" />
-                <button class="btn btn-primary" type="submit"></button>
+                <button class="btn btn-primary" type="submit">Send notification</button>
               </form>
             </div>
             <div class="tab-pane" id="correction" role="tabpanel">
               <form class="card">
                 <!-- require: description of expected-content as compared to found-content -->
                 <input id="report_type" type="hidden" value="correction" />
-                <input id="content-expected" type="text" />
-                <input id="content-found" type="text" />
-                <button class="btn btn-primary" type="submit"></button>
+                <input id="content-expected" type="text" placeholder="Expected: three medium onions" />
+                <input id="content-found" type="text" placeholder="Found: one small onion" />
+                <button class="btn btn-primary" type="submit">Send correction</button>
               </form>
             </div>
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -423,17 +423,17 @@
                 <!-- allow at-least-one of: email address, content re-use policy URL, noindex annotation -->
                 <input name="recipe_id" type="hidden" />
                 <input name="report_type" type="hidden" value="removal_request" />
-                <div class="form-group">
-                  <label for="content-owner-email" data-i18n="problem-reports:content-owner-email-label"></label>
+                <div class="form-floating">
                   <input class="form-control" id="content-owner-email" name="content-owner-email" type="email" placeholder="email@recipes.test" />
+                  <label for="content-owner-email" data-i18n="problem-reports:content-owner-email-label"></label>
                 </div>
-                <div class="form-group">
-                  <label for="content-reuse-policy" data-i18n="problem-reports:content-reuse-policy-label"></label>
+                <div class="form-floating">
                   <input class="form-control" id="content-reuse-policy" name="content-reuse-policy" type="url" placeholder="https://recipes.test/content-reuse-policy.html" />
+                  <label for="content-reuse-policy" data-i18n="problem-reports:content-reuse-policy-label"></label>
                 </div>
                 <div class="form-check">
-                  <label for="content-noindex-directive" data-i18n="problem-reports:content-noindex-directive-label"></label>
                   <input class="form-check-input" id="content-noindex-directive" name="content-noindex-directive" type="checkbox" />
+                  <label for="content-noindex-directive" data-i18n="problem-reports:content-noindex-directive-label"></label>
                 </div>
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-removal-request"></button>
               </form>
@@ -450,13 +450,13 @@
                 <!-- require: description of expected-content as compared to found-content -->
                 <input name="recipe_id" type="hidden" />
                 <input name="report_type" type="hidden" value="correction" />
-                <div class="form-group">
-                  <label for="content-expected" data-i18n="problem-reports:content-expected-label"></label>
+                <div class="form-floating">
                   <input class="form-control" id="content-expected" name="content-expected" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-expected-content" />
+                  <label for="content-expected" data-i18n="problem-reports:content-expected-label"></label>
                 </div>
-                <div class="form-group">
-                  <label for="content-found" data-i18n="problem-reports:content-found-label"></label>
+                <div class="form-floating">
                   <input class="form-control" id="content-found" name="content-found" type="text" data-i18n="[placeholder]problem-reports:placeholder-correction-found-content" />
+                  <label for="content-found" data-i18n="problem-reports:content-found-label"></label>
                 </div>
                 <button class="btn btn-primary" type="submit" data-i18n="problem-reports:submit-correction"></button>
               </form>

--- a/static/api/recipes/search
+++ b/static/api/recipes/search
@@ -1,0 +1,55 @@
+{
+   "authority" : "api",
+   "facets" : {
+      "domains" : [
+         {
+            "count" : 10,
+            "key" : "example-one.test"
+         },
+         {
+            "count" : 5,
+            "key" : "example-two.test"
+         }
+      ]
+   },
+   "refinements" : [
+      "empty_query"
+   ],
+   "results" : [
+      {
+         "author" : "Test Author",
+         "author_url" : null,
+         "directions" : [],
+         "domain" : "example-two.test",
+         "dst" : "https://example-two.test/example-recipe/",
+         "id" : "not-a-genuine-recipe-id",
+         "image_url" : "images/recipes/not-a-genuine-recipe-id.png",
+         "ingredients" : [
+            {
+               "markup" : "<amt><qty>20</qty><unit>g</unit></amt> <ingredient>spaghetti</ingredient>",
+               "product" : {
+                  "category" : null,
+                  "id" : "spaghetti",
+                  "name" : "spaghetti",
+                  "plural" : "spaghetti",
+                  "singular" : "spaghetti",
+                  "state" : "required"
+               },
+               "quantity" : {
+                  "magnitude" : 20,
+                  "units" : "g"
+               }
+            }
+         ],
+         "is_dairy_free" : false,
+         "is_gluten_free" : false,
+         "is_vegan" : false,
+         "is_vegetarian" : true,
+         "rating" : 4.5,
+         "servings" : 2,
+         "time" : 15,
+         "title" : "Spaghetti"
+      }
+   ],
+   "total" : 1
+}

--- a/static/api/recipes/search
+++ b/static/api/recipes/search
@@ -23,7 +23,6 @@
          "domain" : "example-two.test",
          "dst" : "https://example-two.test/example-recipe/",
          "id" : "not-a-genuine-recipe-id",
-         "image_url" : "images/recipes/not-a-genuine-recipe-id.png",
          "ingredients" : [
             {
                "markup" : "<amt><qty>20</qty><unit>g</unit></amt> <ingredient>spaghetti</ingredient>",


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
As described in #272, there are various reasons why users may want to report problems with recipes that appear in the search results.  Currently the main reasons that we anticipate are: requests for recipes to be removed by their owners, reports of unsafe content after hyperlinks to the recipes are followed (e.g. due to domain re-registration, spam or other problems/defacements of recipe websites) and corrections.

This changeset provides the user-interface implementation of problem reporting -- when a user sends a problem report it will be received by an endpoint in the [`api` service](https://github.com/openculinary/api).  To inspect progress on the development of that reporting endpoint, refer to: openculinary/api#126 

### Briefly summarize the changes
1. Add a button within each recipe search result to allow users to send a notification that they have encountered a problem with it.
1. Clicking the problem-report button opens a menu to select one of the three problem-report types (removal requests, unsafe content notifications, and corrections).
1. Selecting any of the problem-report menu items presents a form where the user can provide details (if necessary) about the problem they've encountered; the form also allows the user to change between problem-report types, in case they decide that another report type is more appropriate (or made a mistake selecting a problem report type).

### How have the changes been tested?
1. Local development testing.

### Screenshots
[problem-reports-prototype.webm](https://github.com/user-attachments/assets/959ed3dc-e147-4053-a4ce-e39bb45f4937)

Credit: video recording by GNOME desktop with editing by `ffmpeg` (thanks to a hint on the [`mpv` issue tracker](https://github.com/mpv-player/mpv/issues/4054)).

**List any issues that this change relates to**
Resolves #272.