### PR TITLE
ServiceWorker: do not prefetch API resources

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,6 +77,7 @@ module.exports = (_, env) => {
       ]}),
       new InjectManifest({
         dontCacheBustURLsMatching: /.*/,
+        exclude: [/^api\//],
         swSrc: path.resolve(__dirname, 'src/sw/sw.js')
       }),
       new SubresourceIntegrityPlugin({


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
With changeset #275 we added a static `api/recipes/search` JSON file that is not used in production but that can provide for basic recipe search functionality testing in development without requiring an API server.

Unfortunately, the presence of this additional file in our set of bundled resources meant that Workbox, as intended and sensibly per-design, included that file in the set of resources to precache.  This means that fresh installations and/or perhaps some re-opened stale instances of the RecipeRadar Progressive Web App would request that resource -- among the various others that are indeed required locally for a functional PWA experience.

In production, those requests were routed by our `haproxy` and Kubernetes ingress mechanisms to the [`api` microservice](https://github.com/openculinary/api/), where they would perform and log empty-parameter recipe search results.

Neither that traffic nor the caching of the results are useful, so a straightforward approach -- generalised to all API requests -- is to ignore precaching for any resources that have the HTTP path prefix `api/`.

### Briefly summarize the changes
1. Disables precaching for HTTP requests having the path prefix `api/`.

### How have the changes been tested?
1. N/A

**List any issues that this change relates to**
Relates-to #275 (where the problem was introduced).
Resolves #277.