### PR TITLE
ServiceWorker: include integrity hash in 'index.html'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ license-check:
 	@if [ "${references}" -ne "${checksums}" ]; then echo "error: expected ${references} licenses.txt checksums in index.html but found ${checksums}"; exit 1; fi;
 
 image-finalize:
+	sed --expression 's#integrity="sha512"#integrity="sha512-$(shell openssl dgst -sha512 -binary "public/sw.js" | base64 --wrap 0)"#' --in-place 'public/index.html'
 	buildah copy $(container) 'public' '/usr/share/nginx/html/reciperadar'
 	buildah config --cmd '/usr/sbin/nginx -g "daemon off;"' --port 80 $(container)
 	buildah commit --omit-timestamp --quiet --rm --squash $(container) ${IMAGE_NAME}:${IMAGE_TAG}

--- a/src/index.html
+++ b/src/index.html
@@ -509,5 +509,8 @@
     </footer>
 <% for (index in htmlWebpackPlugin.files.js) { if (htmlWebpackPlugin.files.js[index].match(/^html2canvas\./)) continue; let integrity = htmlWebpackPlugin.files.jsIntegrity[index], src = htmlWebpackPlugin.files.js[index]; %>
     <script integrity="<%= integrity %>" crossorigin="anonymous" src="<%= src %>"<% if (!src.match(/^app\./)) { %> async="async"<% } %>></script><% } %>
+    <!--
+    <script integrity="sha512" crossorigin="anonymous" src="sw.js"></script>
+    -->
   </body>
 </html>


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This application is a [Progressive Web Application](https://web.dev/learn/pwa/progressive-web-apps/), and it includes [Service Worker](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers) code.

Although we don't currently use or provide much functionality in our [Service Worker implementation](https://github.com/openculinary/frontend/blob/e4de79c39acb952cff6edddf0b5a73e9b255078b/src/sw/sw.js), apart from some [basic error handling when recipe search requests fail](https://github.com/openculinary/frontend/blob/e4de79c39acb952cff6edddf0b5a73e9b255078b/src/sw/sw.js#L12-L25), we could do in future -- and service workers can implement powerful functionality.

To hold ourselves to our integrity and safety objectives, we should ensure that our chain-of-integrity, as published using a DNS B (`WebIntegrity`) record, is updated when changes are made to our service worker code.  This was identified as a bug in #279, and this pull request presents a (slightly hacky, unfortunately) solution.

After we build the `index.html` file using webpack, we replace a placeholder `sha512` HTML `integrity` attribute with a dynamically-calcuated SHA512 digest of the `sw.js` (service worker) code asset as processed by webpack.

### Briefly summarize the changes
1. Run a `sed` script during finalization of the container image to insert the `sw.js` SHA512 checksum into the `index.html` file.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Fixes #279.