### PR TITLE
ServiceWorker: additional precache exclusion filters

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,7 +77,10 @@ module.exports = (_, env) => {
       ]}),
       new InjectManifest({
         dontCacheBustURLsMatching: /.*/,
-        exclude: [/^api\//],
+        exclude: [
+          /^\.well-known\//,
+          /^api\//,
+        ],
         swSrc: path.resolve(__dirname, 'src/sw/sw.js')
       }),
       new SubresourceIntegrityPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,6 +80,7 @@ module.exports = (_, env) => {
         exclude: [
           /^\.well-known\//,
           /^api\//,
+          /^locales\//,
         ],
         swSrc: path.resolve(__dirname, 'src/sw/sw.js')
       }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,8 +79,10 @@ module.exports = (_, env) => {
         dontCacheBustURLsMatching: /.*/,
         exclude: [
           /^\.well-known\//,
+          /^ads.txt$/,
           /^api\//,
           /^locales\//,
+          /^robots.txt$/,
         ],
         swSrc: path.resolve(__dirname, 'src/sw/sw.js')
       }),


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Some application resources should not be precached by the application's service worker; they are either not used by the application itself, unlikely to be used, or in some cases are semi-private information (e.g. any ACME challenge files temporarily added by a system operator).

To save bandwidth and not expose those non-public files, we should omit them from the service worker's precache manifest.

### Briefly summarize the changes
1. Exclude various web paths for resources that should not be precached/prefetched by the application's service worker.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Fixes #283.